### PR TITLE
HOCS-1875 - UKVI Campaign - Amend

### DIFF
--- a/server/middleware/entityList.js
+++ b/server/middleware/entityList.js
@@ -35,8 +35,44 @@ async function addEntityListItem(req, res, next) {
     }
 }
 
+async function getEntity(req, res, next) {
+
+    const logger = getLogger(req.request);
+    const { itemUUID } = req.params;
+
+    try {
+        const response = await infoService.get(`/entity/${itemUUID}`, {}, { headers: User.createHeaders(req.user) });
+        res.locals.entity = { simpleName: response.data.simpleName, uuid: response.data.uuid, title: response.data.data.title }
+        next();
+    } catch (error) {
+        logger.error(error);
+        next(error);
+    }
+}
+
+async function returnEntityJson(_, res) {
+    const { locals: { entity } } = res;
+    await res.json(entity);
+}
+
+async function updateEntityListItem(req, res, next) {
+    const logger = getLogger(req.request);
+    const { listName } = req.params;
+
+    try {
+        await infoService.put(`/entity/list/${listName}`, { ...req.body, data: JSON.stringify({ title: req.body.title }) }, { headers: User.createHeaders(req.user) });
+        res.sendStatus(200);
+    } catch (error) {
+        logger.error(error);
+        next(error);
+    }
+}
+
 module.exports = {
     getEntityList,
     returnEntityListJson,
-    addEntityListItem
+    addEntityListItem,
+    getEntity,
+    returnEntityJson,
+    updateEntityListItem
 }

--- a/server/routes/api/entityList.js
+++ b/server/routes/api/entityList.js
@@ -1,7 +1,9 @@
 const router = require('express').Router();
-const { getEntityList, returnEntityListJson, addEntityListItem } = require('../../middleware/entityList');
+const { getEntityList, returnEntityListJson, addEntityListItem, getEntity, returnEntityJson, updateEntityListItem } = require('../../middleware/entityList');
 
-router.get('/:listName', getEntityList, returnEntityListJson);
-router.post('/:listName', addEntityListItem);
+router.get('/list/:listName', getEntityList, returnEntityListJson);
+router.get('/:itemUUID', getEntity, returnEntityJson);
+router.post('/list/update/:listName', updateEntityListItem);
+router.post('/list/:listName', addEntityListItem);
 
 module.exports = router;

--- a/server/routes/api/index.js
+++ b/server/routes/api/index.js
@@ -21,7 +21,7 @@ router.use('/teams', apiTeamRouter);
 router.use('/topics', apiTopicsRouter);
 router.use('/units', apiUnitRouter);
 router.use('/case/withdraw', apiCaseRouter);
-router.use('/entity/list', apiEntityListRouter);
+router.use('/entity', apiEntityListRouter);
 router.use('/users', apiUserRouter);
 router.use('/templates', apiTemplateRouter);
 router.use('/case-types', apiCaseTypeRouter);

--- a/src/shared/models/constants.ts
+++ b/src/shared/models/constants.ts
@@ -57,4 +57,7 @@ export const WITHDRAW_CASE_SUCCESS = 'The case was withdrawn successfully';
 export const ADD_CAMPAIGN_ERROR_DESCRIPTION = 'Something went wrong while adding the campaign. Please try again.';
 export const ADD_CAMPAIGN_SUCCESS = 'The campaign was added successfully';
 export const DUPLICATE_CAMPAIGN_DESCRIPTION = 'A campaign with those details already exists';
+export const AMEND_CAMPAIGN_ERROR_DESCRIPTION = 'Something went wrong while amending the campaign. Please try again.';
+export const AMEND_CAMPAIGN_SUCCESS = 'The campaign was amended successfully';
+export const LOAD_CAMPAIGN_ERROR_DESCRIPTION = 'There was an error retrieving campaign.  Please try refreshing the page.';
 export const LOAD_CAMPAIGNS_ERROR_DESCRIPTION = 'There was an error retrieving campaigns.  Please try refreshing the page.';

--- a/src/shared/pages/list/mpamCampaign/__tests__/__snapshots__/amendCampaign.spec.tsx.snap
+++ b/src/shared/pages/list/mpamCampaign/__tests__/__snapshots__/amendCampaign.spec.tsx.snap
@@ -1,0 +1,92 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`when the amendCampaign component is mounted should initially render blank before item title is returned 1`] = `"<div><div class=\\"govuk-grid-row\\"><div class=\\"govuk-grid-column-two-thirds-from-desktop\\"><a class=\\"govuk-back-link\\" href=\\"/manage-mpam-campaigns\\">Back</a><h1 class=\\"govuk-heading-xl\\">Amend Campaign</h1></div></div><div class=\\"govuk-grid-row\\"><div class=\\"govuk-grid-column-one-half-from-desktop\\"><h3 class=\\"govuk-heading-l\\">Campaign name: </h3><form action=\\"/api/entity/list/update/MPAM_CAMPAIGNS\\" method=\\"POST\\"><input type=\\"hidden\\" name=\\"_csrf\\" value=\\"\\"><div class=\\"govuk-form-group\\"><label for=\\"title\\" id=\\"title-label\\" class=\\"govuk-label govuk-label--s\\">New campaign name</label><input class=\\"govuk-input\\" id=\\"title\\" type=\\"text\\" name=\\"title\\" value=\\"\\"></div><div class=\\"govuk-form-group\\"><label for=\\"simpleName\\" id=\\"simpleName-label\\" class=\\"govuk-label govuk-label--s\\">Campaign code</label><input class=\\"govuk-input\\" id=\\"simpleName\\" type=\\"text\\" name=\\"simpleName\\" disabled=\\"\\" value=\\"\\"></div><input class=\\"govuk-button\\" type=\\"submit\\" value=\\"Submit\\"></form></div></div></div>"`;
+
+exports[`when the amendCampaign component is mounted should render with default props 1`] = `
+<div>
+  <div
+    class="govuk-grid-row"
+  >
+    <div
+      class="govuk-grid-column-two-thirds-from-desktop"
+    >
+      <a
+        class="govuk-back-link"
+        href="/manage-mpam-campaigns"
+      >
+        Back
+      </a>
+      <h1
+        class="govuk-heading-xl"
+      >
+        Amend Campaign
+      </h1>
+    </div>
+  </div>
+  <div
+    class="govuk-grid-row"
+  >
+    <div
+      class="govuk-grid-column-one-half-from-desktop"
+    >
+      <h3
+        class="govuk-heading-l"
+      >
+        Campaign name: 
+      </h3>
+      <form
+        action="/api/entity/list/update/MPAM_CAMPAIGNS"
+        method="POST"
+      >
+        <input
+          name="_csrf"
+          type="hidden"
+          value=""
+        />
+        <div
+          class="govuk-form-group"
+        >
+          <label
+            class="govuk-label govuk-label--s"
+            for="title"
+            id="title-label"
+          >
+            New campaign name
+          </label>
+          <input
+            class="govuk-input"
+            id="title"
+            name="title"
+            type="text"
+            value=""
+          />
+        </div>
+        <div
+          class="govuk-form-group"
+        >
+          <label
+            class="govuk-label govuk-label--s"
+            for="simpleName"
+            id="simpleName-label"
+          >
+            Campaign code
+          </label>
+          <input
+            class="govuk-input"
+            disabled=""
+            id="simpleName"
+            name="simpleName"
+            type="text"
+            value=""
+          />
+        </div>
+        <input
+          class="govuk-button"
+          type="submit"
+          value="Submit"
+        />
+      </form>
+    </div>
+  </div>
+</div>
+`;

--- a/src/shared/pages/list/mpamCampaign/__tests__/__snapshots__/campaignView.spec.tsx.snap
+++ b/src/shared/pages/list/mpamCampaign/__tests__/__snapshots__/campaignView.spec.tsx.snap
@@ -69,7 +69,7 @@ exports[`when the campaignView component is mounted should render with default p
                 <a
                   href="#"
                 >
-                  Edit
+                  Amend
                 </a>
               </td>
             </tr>
@@ -92,7 +92,7 @@ exports[`when the campaignView component is mounted should render with default p
                 <a
                   href="#"
                 >
-                  Edit
+                  Amend
                 </a>
               </td>
             </tr>

--- a/src/shared/pages/list/mpamCampaign/__tests__/amendCampaign.spec.tsx
+++ b/src/shared/pages/list/mpamCampaign/__tests__/amendCampaign.spec.tsx
@@ -1,0 +1,201 @@
+
+import React from 'react';
+import { match, MemoryRouter } from 'react-router-dom';
+import { createBrowserHistory, History, Location } from 'history';
+import { act, render, RenderResult, wait, fireEvent, waitForElement } from '@testing-library/react';
+import { GENERAL_ERROR_TITLE, LOAD_CAMPAIGN_ERROR_DESCRIPTION, AMEND_CAMPAIGN_ERROR_DESCRIPTION } from '../../../../models/constants';
+import AmendCampaign from '../amendCampaign';
+import * as EntityListService from '../../../../services/entityListService';
+import * as useError from '../../../../hooks/useError';
+import { State } from '../amendCampaignState';
+
+let match: match<any>;
+let history: History<any>;
+let location: Location;
+let mockState: State;
+let wrapper: RenderResult;
+
+const useReducerSpy = jest.spyOn(React, 'useReducer');
+const reducerDispatch = jest.fn();
+const useErrorSpy = jest.spyOn(useError, 'default');
+const addFormErrorSpy = jest.fn();
+const clearErrorsSpy = jest.fn();
+const setMessageSpy = jest.fn();
+
+const renderComponent = () => render(
+    <MemoryRouter>
+        <AmendCampaign history={history} location={location} match={match}></AmendCampaign>
+    </MemoryRouter>
+);
+const getItemDetailsSpy = jest.spyOn(EntityListService, 'getItemDetails');
+const updateListItemSpy = jest.spyOn(EntityListService, 'updateListItem');
+beforeEach(() => {
+    history = createBrowserHistory();
+    match = {
+        isExact: true,
+        params: { itemUUID: '__itemId__' },
+        path: '',
+        url: ''
+    };
+
+    location = {
+        hash: '',
+        key: '',
+        pathname: '',
+        search: '',
+        state: {}
+    };
+    mockState = {
+        title: '',
+        originalTitle: '',
+        simpleName: '',
+        uuid: ''
+    };
+
+    getItemDetailsSpy.mockImplementation(() => Promise.resolve({ simpleName: 'testSimpleName', title: 'testTitle', uuid: 'testUUID' }));
+    updateListItemSpy.mockImplementation(() => Promise.resolve());
+    useReducerSpy.mockImplementation(() => [mockState, reducerDispatch]);
+    useErrorSpy.mockImplementation(() => [{}, addFormErrorSpy, clearErrorsSpy, setMessageSpy]);
+    history.push = jest.fn();
+    reducerDispatch.mockReset();
+    addFormErrorSpy.mockReset();
+    clearErrorsSpy.mockReset();
+    setMessageSpy.mockReset();
+    act(() => {
+        wrapper = renderComponent();
+    });
+});
+
+describe('when the amendCampaign component is mounted', () => {
+    it('should render with default props', async () => {
+        expect.assertions(2);
+        wrapper = renderComponent();
+        await wait(() => {
+            expect(getItemDetailsSpy).toHaveBeenCalled();
+            expect(wrapper.container).toMatchSnapshot();
+        });
+    });
+
+    it('should initially render blank before item title is returned', async () => {
+        let wrapper: RenderResult;
+        getItemDetailsSpy.mockReturnValueOnce(Promise.resolve(
+            { simpleName: 'testSimpleName', title: 'testTitle', uuid: 'testUUID' }
+        ));
+        mockState.originalTitle = '';
+        wrapper = renderComponent();
+        expect(wrapper.container.outerHTML).toMatchSnapshot();
+    });
+
+    it('should display an error if the call to retrieve item details fails', async () => {
+        expect.assertions(1);
+        getItemDetailsSpy.mockImplementation(() => Promise.reject('error'));
+
+        wrapper = renderComponent();
+
+        await wait(() => {
+            expect(setMessageSpy).toBeCalledWith({ title: GENERAL_ERROR_TITLE, description: LOAD_CAMPAIGN_ERROR_DESCRIPTION });
+        });
+
+    });
+});
+
+describe('when the new name is entered', () => {
+    it('should be persisted in the page state', async () => {
+        wrapper = renderComponent();
+        getItemDetailsSpy.mockReturnValueOnce(Promise.resolve(
+            { simpleName: 'testSimpleName', title: 'testTitle', uuid: 'testUUID' }
+        ));
+        const nameElement = await waitForElement(async () => {
+            return await wrapper.findByLabelText('New campaign name');
+        });
+
+        fireEvent.change(nameElement, { target: { name: 'title', value: 'newTestCampaignTitle' } });
+
+        await wait(() => {
+
+            expect(reducerDispatch).toHaveBeenCalledWith({ type: 'SetTitle', payload: 'newTestCampaignTitle' });
+        });
+    });
+});
+
+describe('when the submit button is clicked', () => {
+    describe('and the data is filled in', () => {
+
+        beforeEach(async () => {
+            mockState.title = '__displayName__';
+            mockState.simpleName = '__shortCode__';
+            const submitButton = await waitForElement(async () => {
+                return await wrapper.findByText('Submit');
+            });
+
+            fireEvent.click(submitButton);
+        });
+
+        describe('and the service call is successful', () => {
+            it('should redirect to the home page', async () => {
+
+                getItemDetailsSpy.mockReturnValueOnce(Promise.resolve(
+                    { simpleName: 'testSimpleName', title: 'testTitle', uuid: 'testUUID' }
+                ));
+                await wait(() => {
+                    expect(getItemDetailsSpy).toHaveBeenCalled();
+                    expect(updateListItemSpy).toHaveBeenCalled();
+                    expect(history.push).toHaveBeenCalledWith('/', { successMessage: 'The campaign was amended successfully' });
+                });
+            });
+            it('should call the begin submit action', async () => {
+
+                await wait(() => {
+                    expect(clearErrorsSpy).toHaveBeenCalled();
+                });
+            });
+        });
+    });
+    describe('and the data is not filled in', () => {
+        beforeEach(async () => {
+            updateListItemSpy.mockReturnValueOnce(Promise.resolve(
+                { simpleName: 'testSimpleName', title: 'testTitle', uuid: 'testUUID' }
+            ));
+            const submitButton = await waitForElement(async () => {
+                return await wrapper.findByText('Submit');
+            });
+
+            fireEvent.click(submitButton);
+        });
+
+        it('should call the begin submit action', () => {
+            expect(clearErrorsSpy).toHaveBeenCalled();
+        });
+
+        it('should set the error state', () => {
+            expect(addFormErrorSpy).toHaveBeenNthCalledWith(1, { key: 'title', value: 'The New campaign name is required' });
+        });
+    });
+});
+
+describe('when the submit button is clicked', () => {
+    describe('and the data is filled in', () => {
+
+        beforeEach(async () => {
+            updateListItemSpy.mockReset();
+            updateListItemSpy.mockImplementation(() => Promise.reject({ response: { status: 500 } }));
+            mockState.title = '__displayName__';
+            mockState.simpleName = '__shortCode__';
+            const submitButton = await waitForElement(async () => {
+                return await wrapper.findByText('Submit');
+            });
+
+            fireEvent.click(submitButton);
+        });
+
+        describe('and the service call fails', () => {
+            it('should set the error state', () => {
+                expect(setMessageSpy).toHaveBeenCalledWith({ description: AMEND_CAMPAIGN_ERROR_DESCRIPTION, title: GENERAL_ERROR_TITLE });
+            });
+
+            it('should call the begin submit action', () => {
+                expect(clearErrorsSpy).toHaveBeenCalled();
+            });
+        });
+    });
+});

--- a/src/shared/pages/list/mpamCampaign/__tests__/amendCampaignReducer.spec.ts
+++ b/src/shared/pages/list/mpamCampaign/__tests__/amendCampaignReducer.spec.ts
@@ -1,0 +1,49 @@
+import { State } from '../amendCampaignState';
+import { reducer } from '../amendCampaignReducer';
+
+describe('when an action is dispatched', () => {
+    describe('and it is a SetItemDetails action', () => {
+        it('it will update the base state with simpleName, title, originalTitle and uuid', () => {
+            const inputState: State = { simpleName: 'testSimpleName', title: 'testTitle', originalTitle: 'testOriginalTitle', uuid: 'testUUID' };
+            const state = reducer(inputState, {
+                type: 'SetItemDetails', payload: { simpleName: 'testSimpleName2', title: 'testTitle2', uuid: 'testUUID2' }
+
+            });
+            const { simpleName, title, originalTitle, uuid } = state;
+            expect(simpleName).toEqual('testSimpleName2');
+            expect(title).toEqual('testTitle2');
+            expect(originalTitle).toEqual('testTitle2');
+            expect(uuid).toEqual('testUUID2');
+        });
+    });
+
+    describe('and it is a SetTitle action', () => {
+        it('it will update the base state with title', () => {
+            const inputState: State = { simpleName: 'testSimpleName', title: 'testTitle', originalTitle: 'testOriginalTitle', uuid: 'testUUID' };
+            const state = reducer(inputState, {
+                type: 'SetTitle', payload: 'testTitle2'
+
+            });
+            const { simpleName, title, originalTitle, uuid } = state;
+            expect(simpleName).toEqual('testSimpleName');
+            expect(title).toEqual('testTitle2');
+            expect(originalTitle).toEqual('testOriginalTitle');
+            expect(uuid).toEqual('testUUID');
+        });
+    });
+
+    describe('and it is a SetSimpleName action', () => {
+        it('it will update the base state with simpleName', () => {
+            const inputState: State = { simpleName: 'testSimpleName', title: 'testTitle', originalTitle: 'testOriginalTitle', uuid: 'testUUID' };
+            const state = reducer(inputState, {
+                type: 'SetSimpleName', payload: 'testSimpleName2'
+
+            });
+            const { simpleName, title, originalTitle, uuid } = state;
+            expect(simpleName).toEqual('testSimpleName2');
+            expect(title).toEqual('testTitle');
+            expect(originalTitle).toEqual('testOriginalTitle');
+            expect(uuid).toEqual('testUUID');
+        });
+    });
+});

--- a/src/shared/pages/list/mpamCampaign/actions.tsx
+++ b/src/shared/pages/list/mpamCampaign/actions.tsx
@@ -1,8 +1,18 @@
 import EntityListItem from 'shared/models/entityListItem';
 
-export type SetTeamName = {
-    type: 'SetTeamName';
-    payload?: string;
+export type SetItemDetails = {
+    type: 'SetItemDetails';
+    payload: EntityListItem;
+};
+
+export type SetSimpleName = {
+    type: 'SetSimpleName';
+    payload: string;
+};
+
+export type SetTitle = {
+    type: 'SetTitle';
+    payload: string;
 };
 
 export type PopulateCampaigns = {
@@ -11,5 +21,7 @@ export type PopulateCampaigns = {
 };
 
 export type Action =
-    SetTeamName |
-    PopulateCampaigns;
+    SetItemDetails |
+    PopulateCampaigns |
+    SetTitle |
+    SetSimpleName;

--- a/src/shared/pages/list/mpamCampaign/addCampaign.tsx
+++ b/src/shared/pages/list/mpamCampaign/addCampaign.tsx
@@ -15,7 +15,7 @@ import EntityListItem from '../../../models/entityListItem';
 import { validate } from '../../../validation';
 import InputEventData from '../../../models/inputEventData';
 
-interface AddUnitProps extends RouteComponentProps {
+interface AddCampaignProps extends RouteComponentProps {
     csrfToken?: string;
 }
 
@@ -30,7 +30,7 @@ const validationSchema = object({
         .matches(/^[a-zA-Z0-9_,.!? ()&]*$/)
 });
 
-const AddCampaign: React.FC<AddUnitProps> = ({ csrfToken, history }) => {
+const AddCampaign: React.FC<AddCampaignProps> = ({ csrfToken, history }) => {
 
     const [pageError, addFormError, clearErrors, setErrorMessage] = useError('', VALIDATION_ERROR_TITLE);
     const [campaign, dispatch] = React.useReducer<Reducer<EntityListItem, InputEventData>>(reducer, {

--- a/src/shared/pages/list/mpamCampaign/amendCampaign.tsx
+++ b/src/shared/pages/list/mpamCampaign/amendCampaign.tsx
@@ -1,0 +1,116 @@
+import React, { Reducer, useEffect } from 'react';
+import { RouteComponentProps } from 'react-router';
+import { Link } from 'react-router-dom';
+import { object, string } from 'yup';
+import Submit from '../../../common/components/forms/submit';
+import Text from '../../../common/components/forms/text';
+import { ApplicationConsumer } from '../../../contexts/application';
+import { updateListItem, getItemDetails } from '../../../services/entityListService';
+import { reducer } from './amendCampaignReducer';
+import ErrorSummary from '../../../common/components/errorSummary';
+import { GENERAL_ERROR_TITLE, AMEND_CAMPAIGN_ERROR_DESCRIPTION, AMEND_CAMPAIGN_SUCCESS, VALIDATION_ERROR_TITLE, LOAD_CAMPAIGN_ERROR_DESCRIPTION } from '../../../models/constants';
+import useError from '../../../hooks/useError';
+import ErrorMessage from '../../../models/errorMessage';
+import { validate } from '../../../validation';
+import { Action } from './actions';
+import { State } from './amendCampaignState';
+
+interface MatchParams {
+    itemUUID: string;
+}
+interface AmendCampaignProps extends RouteComponentProps<MatchParams> {
+    csrfToken?: string;
+}
+
+const validationSchema = object({
+    title: string()
+        .required()
+        .label('New campaign name')
+        .matches(/^[a-zA-Z0-9_,.!? ()&]*$/)
+});
+
+const AmendCampaign: React.FC<AmendCampaignProps> = ({ csrfToken, history, match }) => {
+    const initialState: State = {
+        uuid: '',
+        title: '',
+        originalTitle: '',
+        simpleName: ''
+    };
+
+    const [pageError, addFormError, clearErrors, setErrorMessage] = useError('', VALIDATION_ERROR_TITLE);
+    const [state, dispatch] = React.useReducer<Reducer<State, Action>>(reducer, initialState);
+
+    const { params: { itemUUID } } = match;
+
+    useEffect(() => {
+        getItemDetails(itemUUID)
+            .then(item => dispatch({ type: 'SetItemDetails', payload: item }))
+            .catch(() => {
+                setErrorMessage(new ErrorMessage(LOAD_CAMPAIGN_ERROR_DESCRIPTION, GENERAL_ERROR_TITLE));
+            });
+    }, []);
+
+    const handleSubmit = (event: React.FormEvent) => {
+        event.preventDefault();
+        clearErrors();
+        if (validate(validationSchema, state, addFormError)) {
+            updateListItem(state, 'MPAM_CAMPAIGNS').then(() => {
+                history.push('/', { successMessage: AMEND_CAMPAIGN_SUCCESS });
+            }).catch((error) => {
+                setErrorMessage(new ErrorMessage(AMEND_CAMPAIGN_ERROR_DESCRIPTION, GENERAL_ERROR_TITLE));
+            });
+        }
+    };
+
+    return (
+        <>
+            <div className="govuk-grid-row">
+                <div className="govuk-grid-column-two-thirds-from-desktop">
+                    <Link to="/manage-mpam-campaigns" className="govuk-back-link">Back</Link>
+                    <ErrorSummary
+                        pageError={pageError}
+                    />
+                    <h1 className="govuk-heading-xl">
+                        Amend Campaign
+                    </h1>
+                </div>
+            </div>
+            <div className="govuk-grid-row">
+                <div className="govuk-grid-column-one-half-from-desktop">
+                    <h3 className="govuk-heading-l">
+                        {`Campaign name: ${state.originalTitle}`}
+                    </h3>
+                    <form action="/api/entity/list/update/MPAM_CAMPAIGNS" method="POST" onSubmit={handleSubmit}>
+                        <input type="hidden" name="_csrf" value={csrfToken} />
+                        <Text
+                            label="New campaign name"
+                            name="title"
+                            type="text"
+                            updateState={({ value }) => dispatch({ type: 'SetTitle', payload: value as string })}
+                            value={state.title}
+                        />
+                        <Text
+                            label="Campaign code"
+                            name="simpleName"
+                            type="text"
+                            disabled={true}
+                            updateState={({ value }) => dispatch({ type: 'SetSimpleName', payload: value as string })}
+                            value={state.simpleName}
+                        />
+                        <Submit />
+                    </form>
+                </div>
+            </div>
+        </>
+    );
+};
+
+const WrappedAddUnit = ({ history, location, match }: RouteComponentProps<MatchParams>) => (
+    <ApplicationConsumer>
+        {({ csrf }) => (
+            <AmendCampaign csrfToken={csrf} history={history} location={location} match={match} />
+        )}
+    </ApplicationConsumer>
+);
+
+export default WrappedAddUnit;

--- a/src/shared/pages/list/mpamCampaign/amendCampaignReducer.ts
+++ b/src/shared/pages/list/mpamCampaign/amendCampaignReducer.ts
@@ -1,0 +1,14 @@
+import { Action } from './actions';
+import { State } from './amendCampaignState';
+
+export const reducer = (state: State, action: Action) => {
+    switch (action.type) {
+        case 'SetItemDetails':
+            return { ...state, title: action.payload.title, originalTitle: action.payload.title, simpleName: action.payload.simpleName, uuid: action.payload.uuid };
+        case 'SetTitle':
+            return { ...state, title: action.payload };
+        case 'SetSimpleName':
+            return { ...state, simpleName: action.payload };
+    }
+    return state;
+};

--- a/src/shared/pages/list/mpamCampaign/amendCampaignState.tsx
+++ b/src/shared/pages/list/mpamCampaign/amendCampaignState.tsx
@@ -1,0 +1,6 @@
+export interface State {
+    simpleName: string;
+    title: string;
+    originalTitle: string;
+    uuid: string;
+}

--- a/src/shared/pages/list/mpamCampaign/campaignsView.tsx
+++ b/src/shared/pages/list/mpamCampaign/campaignsView.tsx
@@ -36,9 +36,10 @@ const CampaignsView: React.FC<TeamMembersProps> = ({ history, match }) => {
             });
     }, []);
 
-    const editCampaign = (campaignUUID: string, campaignSimpleName: string, campaignTitle: string, event: React.FormEvent) => {
+    const amendCampaign = (campaignUUID: string, event: React.FormEvent) => {
         event.preventDefault();
         clearErrors();
+        history.push(`/manage-mpam-campaigns/${campaignUUID}/amend`);
 
     };
 
@@ -61,7 +62,7 @@ const CampaignsView: React.FC<TeamMembersProps> = ({ history, match }) => {
                                         <td className="govuk-table__cell">{campaign.title}</td>
                                         <td className="govuk-table__cell">{campaign.simpleName}</td>
                                         <td className="govuk-table__cell">
-                                            <a href="#" onClick={event => editCampaign(campaign.uuid, campaign.title, campaign.simpleName, event)}>Edit</a>
+                                            <a href="#" onClick={event => amendCampaign(campaign.uuid, event)}>Amend</a>
                                         </td>
                                     </tr>
                                 );

--- a/src/shared/router/routes/index.ts
+++ b/src/shared/router/routes/index.ts
@@ -21,6 +21,7 @@ import AddTeamToUser from '../../pages/user/addTeamToUser/addTeamToUser';
 import WithdrawCase from '../../pages/case/withdrawCase';
 import CampaignsView from '../../pages/list/mpamCampaign/campaignsView';
 import AddCampaign from '../../pages/list/mpamCampaign/addCampaign';
+import AmendCampaign from '../../pages/list/mpamCampaign/amendCampaign';
 
 export interface Route {
     component: React.FunctionComponent | Error;
@@ -161,6 +162,12 @@ const routes = [
         exact: true,
         component: AddCampaign,
         title: 'Add Campaign'
+    },
+    {
+        path: '/manage-mpam-campaigns/:itemUUID/amend',
+        exact: true,
+        component: AmendCampaign,
+        title: 'Amend Campaign'
     },
     {
         component: Error,

--- a/src/shared/services/entityListService.ts
+++ b/src/shared/services/entityListService.ts
@@ -12,3 +12,15 @@ export const createListItem = (item: EntityListItem, listName: string) => new Pr
     .then(() => resolve())
     .catch(reason => reject(reason))
 );
+
+export const getItemDetails = (itemUUID: string) => new Promise<EntityListItem>((resolve, reject) => axios
+    .get(`/api/entity/${itemUUID}`)
+    .then(response => resolve(response.data))
+    .catch(reason => reject(reason))
+);
+
+export const updateListItem = (item: EntityListItem, listName: string) => new Promise((resolve, reject) => axios
+    .post(`/api/entity/list/update/${listName}`, item)
+    .then(() => resolve())
+    .catch(reason => reject(reason))
+);


### PR DESCRIPTION
- created 'Amend Campaign' page
- wired in entity details reading endpoint
- added ability to update entity title (display string)
- list service changes have been kept generic so that it can be reused
if we need to create similar page for any other lists