### PR TITLE
HOCS-1853: optimisation of Text input and date parsing for standard lines

### DIFF
--- a/server/middleware/standardLine.js
+++ b/server/middleware/standardLine.js
@@ -111,7 +111,7 @@ function getLabelForValue(list, value) {
 }
 
 const parseDate = (rawDate) => {
-    const [date] = rawDate.match(/[0-9]{4}-[0-1][0-9]-[0-3][0-9]/g) || [];
+    const [date] = rawDate.match(/\d{4}-(?:0[1-9]|1[012])-(?:0[1-9]|[12][0-9]|3[01])/g) || [];
     if (!date) {
         return null;
     }

--- a/src/shared/pages/standardLineManage/standardLinesView.tsx
+++ b/src/shared/pages/standardLineManage/standardLinesView.tsx
@@ -69,11 +69,8 @@ const StandardLinesView: React.FC<StandardLinesProps> = ({ history, match }) => 
             <div className="govuk-grid-row">
                 <div className="govuk-grid-column-one-third">
                     <div className="govuk-form-group filter-row">
-                        <legend id={'workstack-filter-legend'} className="govuk-fieldset__legend">
-                            <span className="govuk-fieldset__heading govuk-label--s">Filter</span>
-                        </legend>
                         <Text
-                            label=""
+                            label="Filter"
                             name="filter"
                             type="text"
                             updateState={(inputEventData: InputEventData) => dispatch({ type: 'FilterStandardLines', payload: inputEventData.value as string })}


### PR DESCRIPTION
This pull request changes the usage of the Text input for searching standard lines and improves the date matching regex.

Previously we had a legend control that showed the user that the text input field is an 'Filter'. This has now been removed and we use the label on the text control. This allows for the For functionality on the filter to work effectively now and will add focus to the Text field on click.

Alongside this, the regex for the date parsing in standard lines allowed for invalid date (9999-19-39), this has now been optimised to reduce the number of false matches that are possible. We should look at implementing a more thorough pattern matching in the future.