### PR TITLE
HOCS-2173: add apostrophe to accepted topic chars

### DIFF
--- a/src/shared/pages/topic/addChildTopic/addChildTopic.tsx
+++ b/src/shared/pages/topic/addChildTopic/addChildTopic.tsx
@@ -29,7 +29,7 @@ const validationSchema = object({
     displayName: string()
         .required()
         .label('Display Name')
-        .matches(/^[a-zA-Z0-9_,.!? ()&]*$/),
+        .matches(/^[a-zA-Z0-9_,.!?' ()&]*$/),
     selectedParentTopic: object({
         label: string()
             .required()

--- a/src/shared/pages/topic/addParentTopic/addParentTopic.tsx
+++ b/src/shared/pages/topic/addParentTopic/addParentTopic.tsx
@@ -21,7 +21,7 @@ interface AddParentTopicProps extends RouteComponentProps {
 const validationSchema = string()
         .required()
         .label('Display Name')
-        .matches(/^[a-zA-Z0-9_,.!? ()&]*$/)
+        .matches(/^[a-zA-Z0-9_,.!?' ()&]*$/)
         .label('Parent Topic')
 ;
 


### PR DESCRIPTION
At present the user cannot add a parent or child topic with a name that contains a apostrophe in the name. This has now been changed to allow for the user to add these to the names.