### PR TITLE
HOCS-2115 - Home Office sponsorship in CPFG

### DIFF
--- a/server/middleware/__tests__/topic.spec.js
+++ b/server/middleware/__tests__/topic.spec.js
@@ -106,7 +106,7 @@ describe('When the Topic middleware getTopics method is called', () => {
         it('should call the get method on the info service', async () => {
             createHeaders.mockImplementation(() => headers);
             await getTopics(req, res, next);
-            expect(infoService.get).toHaveBeenCalledWith('/topics', { headers: headers });
+            expect(infoService.get).toHaveBeenCalledWith('/topics/active', { headers: headers });
             expect(res.locals.topics).toStrictEqual(mockTopics);
         });
 

--- a/server/middleware/topic.js
+++ b/server/middleware/topic.js
@@ -21,7 +21,7 @@ async function getTopics(req, res, next) {
     const logger = getLogger(req.request);
 
     try {
-        const response = await infoService.get(`/topics`, { headers: User.createHeaders(req.user) });
+        const response = await infoService.get(`/topics/active`, { headers: User.createHeaders(req.user) });
         res.locals.topics = response.data;
         next();
     } catch (error) {

--- a/server/routes/api/topics.js
+++ b/server/routes/api/topics.js
@@ -5,7 +5,7 @@ router.get('', getTopics, returnTopicsJson);
 router.get('/:topicId', getTopic, returnTopicJson);
 router.get('/parents', getParentTopics, returnParentTopicsJson);
 router.post('/parents/:parentTopicId', addTopic);
-router.post('/parent', addParentTopic)
+router.post('/parent', addParentTopic);
 router.post('/dcu', addDCUTeamsToTopic);
 
 module.exports = router;


### PR DESCRIPTION
This PR along with https://github.com/UKHomeOffice/hocs-info-service/pull/254 addresses HOCS-2115 - Home Office sponsorship in CPFG.

The issue was caused by old deactivated subtopics being shown alongside and indistinguishable from new subtopics with same name appearing in the management console. This means that there's a 50/50 chance that the user will link the wrong subtopic to a team.

Changes in this PR:
* Call the new active topics endpoint on the infoservice api so only active topics are displayed when linking a topic to a team