### PR TITLE
HOCS-2363: Increase node max header size.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
     "description": "",
     "main": "index.js",
     "scripts": {
-        "start": "node index.js",
-        "start-dev": "webpack -w --mode=development --env.NODE_ENV=development & nodemon index.js --env.NODE_ENV=development",
+        "start": "node --max-http-header-size 80000 index.js",
+        "start-dev": "webpack -w --mode=development --env.NODE_ENV=development & nodemon --max-http-header-size 80000 index.js --env.NODE_ENV=development",
         "build-dev": "webpack --mode=development --env.NODE_ENV=development",
         "build-prod": "webpack --mode=production --env.NODE_ENV=production",
         "test": "jest --coverage",


### PR DESCRIPTION
After upgrading to node from 8 to 14, the default max header size decreased to 8Kb. This PR overrides the default max header size to 80Kb.