### PR TITLE
HOCS-2403-Mock date in tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13488,6 +13488,12 @@
                 }
             }
         },
+        "jest-date-mock": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/jest-date-mock/-/jest-date-mock-1.0.8.tgz",
+            "integrity": "sha512-0Lyp+z9xvuNmLbK+5N6FOhSiBeux05Lp5bbveFBmYo40Aggl2wwxFoIrZ+rOWC8nDNcLeBoDd2miQdEDSf3iQw==",
+            "dev": true
+        },
         "jest-diff": {
             "version": "25.2.3",
             "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
         "eslint-plugin-react": "^7.11.1",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^25.2.4",
+        "jest-date-mock": "^1.0.8",
         "jest-enzyme": "^7.0.1",
         "lint-staged": "^7.3.0",
         "mini-css-extract-plugin": "^0.4.0",

--- a/src/shared/common/components/forms/__tests__/date.spec.tsx
+++ b/src/shared/common/components/forms/__tests__/date.spec.tsx
@@ -1,8 +1,17 @@
 import React from 'react';
 import { render, shallow } from 'enzyme';
+import { advanceTo, clear } from 'jest-date-mock';
 import DateInput from '../date';
 
 describe('Form date component', () => {
+    beforeAll(() => {
+        advanceTo(new Date(2021, 2, 4, 0, 0, 0));
+    });
+
+    afterAll(() => {
+        clear();
+    });
+
     it('should render with default props', () => {
         expect(
             render(<DateInput name="date-field" updateState={() => null} />)


### PR DESCRIPTION
HOCS-2403-Internal Bug: DateInput Component sets maxYear to current date + 100 years breaking tests every year
    
* mock date in tests so snapshot tests don't break

