### PR TITLE
HOCS-2520 Allow dashes in topic names

### DIFF
--- a/src/shared/pages/topic/addChildTopic/__tests__/addChildTopic.spec.tsx
+++ b/src/shared/pages/topic/addChildTopic/__tests__/addChildTopic.spec.tsx
@@ -183,4 +183,56 @@ describe('when the submit button is clicked', () => {
             expect(addFormErrorSpy).toHaveBeenNthCalledWith(2, { key: 'selectedParentTopic.label', value: 'The Parent Topic is required' });
         });
     });
+
+    describe('with invalid characters', () => {
+        beforeEach(async () => {
+            mockState.displayName = 'Invalid@Topic';
+            mockState.selectedParentTopic = { label: '__label__', value: '__value__' };
+            const submitButton = await waitForElement(async () => {
+                return await wrapper.findByText('Submit');
+            });
+
+            fireEvent.click(submitButton);
+        });
+
+        it('should call the begin submit action', () => {
+            expect.assertions(1);
+
+            expect(clearErrorsSpy).toHaveBeenCalled();
+        });
+
+        it('should set the error state', async () => {
+            expect.assertions(1);
+
+            await wait(() => {
+                expect(addFormErrorSpy).toHaveBeenCalledWith({ key: 'displayName', value: 'The Display Name contains invalid characters' });
+            });
+        });
+    });
+
+    describe('with valid characters', () => {
+        beforeEach(async () => {
+            mockState.displayName = 'Valid-Topic';
+            mockState.selectedParentTopic = { label: '__label__', value: '__value__' };
+            const submitButton = await waitForElement(async () => {
+                return await wrapper.findByText('Submit');
+            });
+
+            fireEvent.click(submitButton);
+        });
+
+        it('should call the begin submit action', () => {
+            expect.assertions(1);
+
+            expect(clearErrorsSpy).toHaveBeenCalled();
+        });
+
+        it('should set the error state', async () => {
+            expect.assertions(1);
+
+            await wait(() => {
+                expect(addFormErrorSpy).toBeCalledTimes(0);
+            });
+        });
+    });
 });

--- a/src/shared/pages/topic/addChildTopic/addChildTopic.tsx
+++ b/src/shared/pages/topic/addChildTopic/addChildTopic.tsx
@@ -29,7 +29,7 @@ const validationSchema = object({
     displayName: string()
         .required()
         .label('Display Name')
-        .matches(/^[a-zA-Z0-9_,.!?' ()&]*$/),
+        .matches(/^[a-zA-Z0-9_,.!?' ()&-]*$/),
     selectedParentTopic: object({
         label: string()
             .required()

--- a/src/shared/pages/topic/addParentTopic/__tests__/addParentTopic.spec.tsx
+++ b/src/shared/pages/topic/addParentTopic/__tests__/addParentTopic.spec.tsx
@@ -192,4 +192,56 @@ describe('when the submit button is clicked', () => {
             });
         });
     });
+
+    describe('with invalid characters', () => {
+        beforeEach(async () => {
+            useStateSpy.mockImplementationOnce(() => ['Invalid@Topic', setDisplayNameSpy]);
+
+            const submitButton = await waitForElement(async () => {
+                return await wrapper.findByText('Submit');
+            });
+
+            fireEvent.click(submitButton);
+        });
+
+        it('should call the begin submit action', () => {
+            expect.assertions(1);
+
+            expect(clearErrorsSpy).toHaveBeenCalled();
+        });
+
+        it('should set the error state', async () => {
+            expect.assertions(1);
+
+            await wait(() => {
+                expect(addFormErrorSpy).toHaveBeenCalledWith({ key: undefined, value: 'The Parent Topic contains invalid characters' });
+            });
+        });
+    });
+
+    describe('with valid characters', () => {
+        beforeEach(async () => {
+            useStateSpy.mockImplementationOnce(() => ['Invalid-Topic', setDisplayNameSpy]);
+
+            const submitButton = await waitForElement(async () => {
+                return await wrapper.findByText('Submit');
+            });
+
+            fireEvent.click(submitButton);
+        });
+
+        it('should call the begin submit action', () => {
+            expect.assertions(1);
+
+            expect(clearErrorsSpy).toHaveBeenCalled();
+        });
+
+        it('should set the error state', async () => {
+            expect.assertions(1);
+
+            await wait(() => {
+                expect(addFormErrorSpy).toBeCalledTimes(0);
+            });
+        });
+    });
 });

--- a/src/shared/pages/topic/addParentTopic/addParentTopic.tsx
+++ b/src/shared/pages/topic/addParentTopic/addParentTopic.tsx
@@ -21,7 +21,7 @@ interface AddParentTopicProps extends RouteComponentProps {
 const validationSchema = string()
     .required()
     .label('Display Name')
-    .matches(/^[a-zA-Z0-9_,.!? ()&]*$/)
+    .matches(/^[a-zA-Z0-9_,.!? ()&-]*$/)
     .label('Parent Topic')
 ;
 


### PR DESCRIPTION
- Change `validationSchema` regex for `addParentTopic.tsx` and `addChildTopic.tsx` to allow dashes.
- Add tests for both components (includes tests for invalid values as there were no tests that covered that already).