### PR TITLE
HOCS-2644: drone v1 migration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
+build
+coverage
 node_modules
 npm-debug.log

--- a/.drone-v1.yml
+++ b/.drone-v1.yml
@@ -1,0 +1,258 @@
+---
+kind: pipeline
+type: kubernetes
+name: build
+
+trigger:
+  event:
+    - push
+
+steps:
+  - name: install dependencies
+    image: node:14.15.4-alpine
+    commands:
+      - npm --loglevel warn install --production=false --no-optional
+
+  - name: build project
+    image: node:14.15.4-alpine
+    commands:
+      - npm run build-prod
+    depends_on:
+      - install dependencies
+
+  - name: test project
+    image: node:14.15.4-alpine
+    commands:
+      - npm test
+    depends_on:
+      - install dependencies
+
+  - name: lint project
+    image: node:14.15.4-alpine
+    commands:
+      - npm run lint
+    depends_on:
+      - install dependencies
+
+  - name: build & push
+    image: plugins/docker
+    settings:
+      registry: quay.io
+      repo: quay.io/ukhomeofficedigital/hocs-management-ui
+      tags:
+        - build_${DRONE_BUILD_NUMBER}
+        - ${DRONE_COMMIT_SHA}
+        - branch-${DRONE_COMMIT_BRANCH/\//_}
+    environment:
+      DOCKER_PASSWORD:
+        from_secret: QUAY_ROBOT_TOKEN
+      DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
+    when:
+      branch:
+        exclude:
+          - main
+    depends_on:
+      - build project
+      - test project
+      - lint project
+
+  - name: build & push main
+    image: plugins/docker
+    settings:
+      registry: quay.io
+      repo: quay.io/ukhomeofficedigital/hocs-management-ui
+      tags:
+        - build_${DRONE_BUILD_NUMBER}
+        - ${DRONE_COMMIT_SHA}
+        - branch-${DRONE_COMMIT_BRANCH/\//_}
+        - latest
+    environment:
+      DOCKER_PASSWORD:
+        from_secret: QUAY_ROBOT_TOKEN
+      DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
+    when:
+      branch:
+        - main
+    depends_on:
+      - build project
+      - test project
+      - lint project
+
+---
+kind: pipeline
+type: kubernetes
+name: deploy
+depends_on:
+  - build
+trigger:
+  event:
+    exclude:
+      - pull_request
+      - tag
+
+services:
+  - name: docker
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
+
+environment:
+  DOCKER_HOST: tcp://docker:2375
+
+steps:
+  - name: clone kube repo
+    image: plugins/git
+    commands:
+      - git clone https://github.com/UKHomeOffice/kube-hocs-management-ui.git
+
+  - name: deploy to cs-dev
+    image: quay.io/ukhomeofficedigital/kd:v1.16.0
+    environment:
+      ENVIRONMENT: cs-dev
+      VERSION: build_${DRONE_BUILD_NUMBER}
+      KUBE_TOKEN:
+        from_secret: hocs_management_ui_cs_dev
+    commands:
+      - cd kube-hocs-management_ui
+      - ./deploy.sh
+    when:
+      branch:
+        - main
+      event:
+        - push
+    depends_on:
+      - clone kube repo
+
+  - name: deploy to wcs-dev
+    image: quay.io/ukhomeofficedigital/kd:v1.16.0
+    environment:
+      ENVIRONMENT: wcs-dev
+      VERSION: build_${DRONE_BUILD_NUMBER}
+      KUBE_TOKEN:
+        from_secret: hocs_management_ui_wcs_dev
+    commands:
+      - cd kube-hocs-management-ui
+      - ./deploy.sh
+    when:
+      branch:
+        - main
+      event:
+        - push
+    depends_on:
+      - clone kube repo
+
+  - name: wait for docker
+    image: docker
+    commands:
+      - n=0; until docker stats --no-stream; do echo "Waiting for Docker $n"; n=$((n +1)); sleep 1; done
+    when:
+      event:
+        - promote
+      target:
+        - release
+
+  - name: generate & tag build
+    image: quay.io/ukhomeofficedigital/hocs-version-bot:latest
+    commands:
+      - >
+        /app/hocs-deploy
+        --dockerRepository=quay.io/ukhomeofficedigital
+        --environment=qa
+        --registryPassword=$${DOCKER_PASSWORD}
+        --registryUser=ukhomeofficedigital+hocs_quay_robot
+        --service=hocs-management-ui
+        --serviceGitToken=$${GITHUB_TOKEN}
+        --sourceBuild=$${VERSION}
+        --version=$${SEMVER}
+        --versionRepo="https://gitlab.digital.homeoffice.gov.uk/hocs/hocs-versions.git"
+        --versionRepoServiceToken=$${GITLAB_TOKEN}
+    environment:
+      DOCKER_API_VERSION: 1.40
+      DOCKER_PASSWORD:
+        from_secret: QUAY_ROBOT_TOKEN
+      GITLAB_TOKEN:
+        from_secret: GITLAB_TOKEN
+      GITHUB_TOKEN:
+        from_secret: GITHUB_TOKEN
+    depends_on:
+      - wait for docker
+    when:
+      event:
+        - promote
+      target:
+        - release
+
+  - name: deploy to cs-qa
+    image: quay.io/ukhomeofficedigital/kd:v1.16.0
+    commands:
+      - source version.txt
+      - echo $VERSION
+      - cd kube-hocs-management-ui
+      - ./deploy.sh
+    environment:
+      ENVIRONMENT: cs-qa
+      KUBE_TOKEN:
+        from_secret: hocs_management_ui_cs_qa
+    when:
+      event:
+        - promote
+      target:
+        - release
+    depends_on:
+      - clone kube repo
+      - generate & tag build
+
+  - name: deploy to wcs-qa
+    image: quay.io/ukhomeofficedigital/kd:v1.16.0
+    commands:
+      - source version.txt
+      - echo $VERSION
+      - cd kube-hocs-management_ui
+      - ./deploy.sh
+    environment:
+      ENVIRONMENT: wcs-qa
+      KUBE_TOKEN:
+        from_secret: hocs_management_ui_wcs_qa
+    when:
+      event:
+        - promote
+      target:
+        - release
+    depends_on:
+      - clone kube repo
+      - generate & tag build
+
+  - name: deploy to not prod
+    image: quay.io/ukhomeofficedigital/kd:v1.16.0
+    commands:
+      - cd kube-hocs-management-ui
+      - ./deploy.sh
+    environment:
+      ENVIRONMENT: ${DRONE_DEPLOY_TO}
+      KUBE_TOKEN:
+        from_secret: hocs_management_ui_${DRONE_DEPLOY_TO/-/_}
+    when:
+      event:
+        - promote
+      target:
+        exclude:
+          - release
+          - "*-prod"
+    depends_on:
+      - clone kube repo
+
+  - name: deploy to prod
+    image: quay.io/ukhomeofficedigital/kd:v1.16.0
+    commands:
+      - cd kube-hocs-management-ui
+      - ./deploy.sh
+    environment:
+      ENVIRONMENT: ${DRONE_DEPLOY_TO}
+      KUBE_TOKEN:
+        from_secret: hocs_management_ui_${DRONE_DEPLOY_TO/-/_}
+    when:
+      event:
+        - promote
+      target:
+        include:
+          - "*-prod"
+    depends_on:
+      - clone kube repo

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir -p /app && \
 WORKDIR /app
 COPY . /app
 RUN npm install
-RUN npm run build-dev
+RUN npm run build-prod
 
 USER ${USER_ID}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,41 +5,66 @@
     "requires": true,
     "dependencies": {
         "@babel/cli": {
-            "version": "7.8.4",
-            "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.8.4.tgz",
-            "integrity": "sha512-XXLgAm6LBbaNxaGhMAznXXaxtCWfuv6PIDJ9Alsy9JYTOh+j2jJz+L/162kkfU1j/pTSxK1xGmlwI4pdIMkoag==",
+            "version": "7.13.10",
+            "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.13.10.tgz",
+            "integrity": "sha512-lYSBC7B4B9hJ7sv0Ojx1BrGhuzCoOIYfLjd+Xpd4rOzdS+a47yi8voV8vFkfjlZR1N5qZO7ixOCbobUdT304PQ==",
             "dev": true,
             "requires": {
-                "chokidar": "^2.1.8",
+                "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents",
+                "chokidar": "^3.4.0",
                 "commander": "^4.0.1",
                 "convert-source-map": "^1.1.0",
                 "fs-readdir-recursive": "^1.1.0",
                 "glob": "^7.0.0",
-                "lodash": "^4.17.13",
+                "lodash": "^4.17.19",
                 "make-dir": "^2.1.0",
                 "slash": "^2.0.0",
                 "source-map": "^0.5.0"
             },
             "dependencies": {
-                "chokidar": {
-                    "version": "2.1.8",
-                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
-                    "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+                "anymatch": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+                    "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "anymatch": "^2.0.0",
-                        "async-each": "^1.0.1",
-                        "braces": "^2.3.2",
-                        "fsevents": "^1.2.7",
-                        "glob-parent": "^3.1.0",
-                        "inherits": "^2.0.3",
-                        "is-binary-path": "^1.0.0",
-                        "is-glob": "^4.0.0",
                         "normalize-path": "^3.0.0",
-                        "path-is-absolute": "^1.0.0",
-                        "readdirp": "^2.2.1",
-                        "upath": "^1.1.1"
+                        "picomatch": "^2.0.4"
+                    }
+                },
+                "binary-extensions": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+                    "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+                    "dev": true,
+                    "optional": true
+                },
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "chokidar": {
+                    "version": "3.5.1",
+                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+                    "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "anymatch": "~3.1.1",
+                        "braces": "~3.0.2",
+                        "fsevents": "~2.3.1",
+                        "glob-parent": "~5.1.0",
+                        "is-binary-path": "~2.1.0",
+                        "is-glob": "~4.0.1",
+                        "normalize-path": "~3.0.0",
+                        "readdirp": "~3.5.0"
                     }
                 },
                 "commander": {
@@ -48,6 +73,50 @@
                     "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
                     "dev": true
                 },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "fsevents": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+                    "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+                    "dev": true,
+                    "optional": true
+                },
+                "glob-parent": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+                    "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "is-glob": "^4.0.1"
+                    }
+                },
+                "is-binary-path": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+                    "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "binary-extensions": "^2.0.0"
+                    }
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true,
+                    "optional": true
+                },
                 "normalize-path": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -55,11 +124,40 @@
                     "dev": true,
                     "optional": true
                 },
+                "readdirp": {
+                    "version": "3.5.0",
+                    "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+                    "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "picomatch": "^2.2.1"
+                    },
+                    "dependencies": {
+                        "picomatch": {
+                            "version": "2.2.2",
+                            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+                            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
                 "source-map": {
                     "version": "0.5.7",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
                     "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
                     "dev": true
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
                 }
             }
         },
@@ -3644,6 +3742,35 @@
                 "@types/yargs": "^12.0.9"
             }
         },
+        "@nicolo-ribaudo/chokidar-2": {
+            "version": "2.1.8-no-fsevents",
+            "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.tgz",
+            "integrity": "sha512-+nb9vWloHNNMFHjGofEam3wopE3m1yuambrrd/fnPc+lFOMB9ROTqQlche9ByFWNkdNqfSgR/kkQtQ8DzEWt2w==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "anymatch": "^2.0.0",
+                "async-each": "^1.0.1",
+                "braces": "^2.3.2",
+                "glob-parent": "^3.1.0",
+                "inherits": "^2.0.3",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^4.0.0",
+                "normalize-path": "^3.0.0",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.2.1",
+                "upath": "^1.1.1"
+            },
+            "dependencies": {
+                "normalize-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+                    "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
         "@nodelib/fs.scandir": {
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
@@ -4468,9 +4595,9 @@
             "dev": true
         },
         "aggregate-error": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
-            "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+            "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
             "dev": true,
             "requires": {
                 "clean-stack": "^2.0.0",
@@ -4788,7 +4915,8 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
             "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "async-foreach": {
             "version": "0.1.3",
@@ -5878,7 +6006,8 @@
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
             "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "bluebird": {
             "version": "3.7.2",
@@ -6209,9 +6338,9 @@
             },
             "dependencies": {
                 "graceful-fs": {
-                    "version": "4.2.3",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-                    "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+                    "version": "4.2.6",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+                    "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
                     "dev": true
                 },
                 "lru-cache": {
@@ -6387,6 +6516,7 @@
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
             "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "anymatch": "^2.0.0",
                 "async-each": "^1.0.1",
@@ -6406,7 +6536,8 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
                     "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -7513,9 +7644,9 @@
             }
         },
         "dot-prop": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-            "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+            "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
             "dev": true,
             "requires": {
                 "is-obj": "^1.0.0"
@@ -7575,18 +7706,26 @@
             "dev": true
         },
         "elliptic": {
-            "version": "6.5.3",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-            "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+            "version": "6.5.4",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+            "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
+                "bn.js": "^4.11.9",
+                "brorand": "^1.1.0",
                 "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
+                "hmac-drbg": "^1.0.1",
+                "inherits": "^2.0.4",
+                "minimalistic-assert": "^1.0.1",
+                "minimalistic-crypto-utils": "^1.0.1"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.12.0",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+                    "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+                    "dev": true
+                }
             }
         },
         "emoji-regex": {
@@ -10492,6 +10631,7 @@
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "is-glob": "^3.1.0",
                 "path-dirname": "^1.0.0"
@@ -10502,6 +10642,7 @@
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "is-extglob": "^2.1.0"
                     }
@@ -11066,9 +11207,9 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "ini": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
             "dev": true
         },
         "interpret": {
@@ -11132,6 +11273,7 @@
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "binary-extensions": "^1.0.0"
             }
@@ -13750,9 +13892,9 @@
             }
         },
         "jest-environment-enzyme": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/jest-environment-enzyme/-/jest-environment-enzyme-7.0.2.tgz",
-            "integrity": "sha512-cBBWX3ZCR4JJR6ml6cTYLH1fdBZ2QEbywY6yrkgTP6OZgE+Nh6Agu0g99uJha2F36+zRFS/xkk8AIEAJvLtzQQ==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/jest-environment-enzyme/-/jest-environment-enzyme-7.1.2.tgz",
+            "integrity": "sha512-3tfaYAzO7qZSRrv+srQnfK16Vu5XwH/pHi8FpoqSHjKKngbHzXf7aBCBuWh8y3w0OtknHRfDMFrC60Khj+g1hA==",
             "dev": true,
             "requires": {
                 "jest-environment-jsdom": "^24.0.0"
@@ -20284,8 +20426,7 @@
         "minimist": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-            "dev": true
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "minipass": {
             "version": "3.1.1",
@@ -20323,9 +20464,9 @@
             }
         },
         "minipass-pipeline": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.2.tgz",
-            "integrity": "sha512-3JS5A2DKhD2g0Gg8x3yamO0pj7YeKGwVlDS90pF++kxptwx/F+B//roxf9SqYil5tQo65bijy+dAuAFZmYOouA==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+            "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
             "dev": true,
             "requires": {
                 "minipass": "^3.0.0"
@@ -20389,18 +20530,11 @@
             }
         },
         "mkdirp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
             "requires": {
-                "minimist": "0.0.8"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "0.0.8",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-                }
+                "minimist": "^1.2.5"
             }
         },
         "moo": {
@@ -21420,7 +21554,8 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
             "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "path-exists": {
             "version": "3.0.0",
@@ -22291,6 +22426,7 @@
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
             "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "graceful-fs": "^4.1.11",
                 "micromatch": "^3.1.10",
@@ -23866,30 +24002,54 @@
             }
         },
         "terser-webpack-plugin": {
-            "version": "2.3.5",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-2.3.5.tgz",
-            "integrity": "sha512-WlWksUoq+E4+JlJ+h+U+QUzXpcsMSSNXkDy9lBVkSqDn1w23Gg29L/ary9GeJVYCGiNJJX7LnVc4bwL1N3/g1w==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-2.3.8.tgz",
+            "integrity": "sha512-/fKw3R+hWyHfYx7Bv6oPqmk4HGQcrWLtV3X6ggvPuwPNHSnzvVV51z6OaaCOus4YLjutYGOz3pEpbhe6Up2s1w==",
             "dev": true,
             "requires": {
                 "cacache": "^13.0.1",
-                "find-cache-dir": "^3.2.0",
-                "jest-worker": "^25.1.0",
-                "p-limit": "^2.2.2",
-                "schema-utils": "^2.6.4",
-                "serialize-javascript": "^2.1.2",
+                "find-cache-dir": "^3.3.1",
+                "jest-worker": "^25.4.0",
+                "p-limit": "^2.3.0",
+                "schema-utils": "^2.6.6",
+                "serialize-javascript": "^4.0.0",
                 "source-map": "^0.6.1",
-                "terser": "^4.4.3",
+                "terser": "^4.6.12",
                 "webpack-sources": "^1.4.3"
             },
             "dependencies": {
+                "ajv": {
+                    "version": "6.12.6",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "ajv-keywords": {
+                    "version": "3.5.2",
+                    "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+                    "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+                    "dev": true
+                },
+                "fast-deep-equal": {
+                    "version": "3.1.3",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+                    "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+                    "dev": true
+                },
                 "find-cache-dir": {
-                    "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.2.0.tgz",
-                    "integrity": "sha512-1JKclkYYsf1q9WIJKLZa9S9muC+08RIjzAlLrK4QcYLJMS6mk9yombQ9qf+zJ7H9LS800k0s44L4sDq9VYzqyg==",
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+                    "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
                     "dev": true,
                     "requires": {
                         "commondir": "^1.0.1",
-                        "make-dir": "^3.0.0",
+                        "make-dir": "^3.0.2",
                         "pkg-dir": "^4.1.0"
                     }
                 },
@@ -23910,9 +24070,9 @@
                     "dev": true
                 },
                 "jest-worker": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.1.0.tgz",
-                    "integrity": "sha512-ZHhHtlxOWSxCoNOKHGbiLzXnl42ga9CxDr27H36Qn+15pQZd3R/F24jrmjDelw9j/iHUIWMWs08/u2QN50HHOg==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.5.0.tgz",
+                    "integrity": "sha512-/dsSmUkIy5EBGfv/IjjqmFxrNAUpBERfGs1oHROyD7yxjG/w+t0GOJDX8O1k32ySmd7+a5IhnJU2qQFcJ4n1vw==",
                     "dev": true,
                     "requires": {
                         "merge-stream": "^2.0.0",
@@ -23929,9 +24089,9 @@
                     }
                 },
                 "make-dir": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
-                    "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+                    "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
                     "dev": true,
                     "requires": {
                         "semver": "^6.0.0"
@@ -23944,9 +24104,9 @@
                     "dev": true
                 },
                 "p-limit": {
-                    "version": "2.2.2",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-                    "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                    "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
                     "dev": true,
                     "requires": {
                         "p-try": "^2.0.0"
@@ -23977,13 +24137,14 @@
                     }
                 },
                 "schema-utils": {
-                    "version": "2.6.4",
-                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.4.tgz",
-                    "integrity": "sha512-VNjcaUxVnEeun6B2fiiUDjXXBtD4ZSH7pdbfIu1pOFwgptDPLMo/z9jr4sUfsjFVPqDCEin/F7IYlq7/E6yDbQ==",
+                    "version": "2.7.1",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+                    "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
                     "dev": true,
                     "requires": {
-                        "ajv": "^6.10.2",
-                        "ajv-keywords": "^3.4.1"
+                        "@types/json-schema": "^7.0.5",
+                        "ajv": "^6.12.4",
+                        "ajv-keywords": "^3.5.2"
                     }
                 },
                 "semver": {
@@ -23993,18 +24154,32 @@
                     "dev": true
                 },
                 "serialize-javascript": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-                    "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
-                    "dev": true
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+                    "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+                    "dev": true,
+                    "requires": {
+                        "randombytes": "^2.1.0"
+                    }
                 },
                 "supports-color": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
                     "dev": true,
                     "requires": {
                         "has-flag": "^4.0.0"
+                    }
+                },
+                "terser": {
+                    "version": "4.8.0",
+                    "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
+                    "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+                    "dev": true,
+                    "requires": {
+                        "commander": "^2.20.0",
+                        "source-map": "~0.6.1",
+                        "source-map-support": "~0.5.12"
                     }
                 },
                 "webpack-sources": {
@@ -24530,7 +24705,8 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
             "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "update-notifier": {
             "version": "2.5.0",
@@ -24763,14 +24939,152 @@
             }
         },
         "watchpack": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.1.tgz",
-            "integrity": "sha512-+IF9hfUFOrYOOaKyfaI7h7dquUIOgyEMoQMLA7OP5FxegKA2+XdXThAZ9TU2kucfhDH7rfMHs1oPYziVGWRnZA==",
+            "version": "1.7.5",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
+            "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
             "dev": true,
             "requires": {
-                "chokidar": "^2.1.8",
+                "chokidar": "^3.4.1",
                 "graceful-fs": "^4.1.2",
-                "neo-async": "^2.5.0"
+                "neo-async": "^2.5.0",
+                "watchpack-chokidar2": "^2.0.1"
+            },
+            "dependencies": {
+                "anymatch": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+                    "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "normalize-path": "^3.0.0",
+                        "picomatch": "^2.0.4"
+                    }
+                },
+                "binary-extensions": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+                    "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+                    "dev": true,
+                    "optional": true
+                },
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "chokidar": {
+                    "version": "3.5.1",
+                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+                    "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "anymatch": "~3.1.1",
+                        "braces": "~3.0.2",
+                        "fsevents": "~2.3.1",
+                        "glob-parent": "~5.1.0",
+                        "is-binary-path": "~2.1.0",
+                        "is-glob": "~4.0.1",
+                        "normalize-path": "~3.0.0",
+                        "readdirp": "~3.5.0"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "fsevents": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+                    "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+                    "dev": true,
+                    "optional": true
+                },
+                "glob-parent": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+                    "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "is-glob": "^4.0.1"
+                    }
+                },
+                "is-binary-path": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+                    "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "binary-extensions": "^2.0.0"
+                    }
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true,
+                    "optional": true
+                },
+                "normalize-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+                    "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+                    "dev": true,
+                    "optional": true
+                },
+                "readdirp": {
+                    "version": "3.5.0",
+                    "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+                    "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "picomatch": "^2.2.1"
+                    },
+                    "dependencies": {
+                        "picomatch": {
+                            "version": "2.2.2",
+                            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+                            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                }
+            }
+        },
+        "watchpack-chokidar2": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz",
+            "integrity": "sha512-nCFfBIPKr5Sh61s4LPpy1Wtfi0HE8isJ3d2Yb5/Ppw2P2B/3eVSEBjKfN0fmHJSK14+31KwMKmcrzs2GM4P0Ww==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "chokidar": "^2.1.8"
             }
         },
         "webidl-conversions": {
@@ -25009,9 +25323,9 @@
                     }
                 },
                 "yargs-parser": {
-                    "version": "13.1.1",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-                    "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+                    "version": "13.1.2",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+                    "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
                     "dev": true,
                     "requires": {
                         "camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "author": "",
     "license": "ISC",
     "devDependencies": {
-        "@babel/cli": "^7.8.4",
+        "@babel/cli": "^7.13.10",
         "@babel/core": "^7.1.2",
         "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
         "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
@@ -84,7 +84,7 @@
         "postcss-loader": "^2.1.4",
         "pre-commit": "^1.2.2",
         "sass-loader": "^10.0.0",
-        "terser-webpack-plugin": "^2.3.5",
+        "terser-webpack-plugin": "^2.3.8",
         "ts-jest": "^25.3.0",
         "ts-loader": "^6.0.4",
         "typescript": "^3.9.7",


### PR DESCRIPTION
This change implements the necessary changes to use Drone V1 as V0.8
is going to be deprecated. Changes include:
- Add build, test to pipeline (previously wasn't testing the code, only
ensuring the build was successful
- Removed pull request checks
- Changed to push to build_XXX instead of build-XXX
- Added commit sha tag
- Switched to using KUBE_TOKEN as defined in Drone rather than the
kube repo
- Added acyclic dependency graph for asynchronous build steps
- Made a QA release always release to both QA environments
consolidated build steps where possible
- Ensure production build is build (previously was development)

Run `npm audit --fix`, this audits all the dependencies through the 
application and updates them. This improves the reports from 36 to 10 
to eventually fix.