### PR TITLE
HOCS-2743: edit team name

### DIFF
--- a/server/middleware/__tests__/team.spec.js
+++ b/server/middleware/__tests__/team.spec.js
@@ -1,5 +1,5 @@
 import {
-    getTeams, getTeamMembers, returnTeamMembersJson, returnTeamsJson, addTeam
+    getTeams, getTeamMembers, returnTeamMembersJson, returnTeamsJson, addTeam, updateTeamName
 } from '../team';
 import { infoService } from '../../clients/index';
 
@@ -43,10 +43,10 @@ describe('getTeamsForUser', () => {
         {
             label: 'team1',
             value: 'teamId1'
-        },{
+        }, {
             label: 'team2',
             value: 'teamId2'
-        },{
+        }, {
             label: 'team3',
             value: 'teamId3'
         }
@@ -162,6 +162,39 @@ describe('addTeam', () => {
     it('should catch and log error if post request fails', async () => {
         infoService.post.mockImplementation(() => Promise.reject());
         await addTeam(req, res, next);
+        expect(logError).toHaveBeenCalled();
+        expect(next).toHaveBeenCalled();
+    });
+});
+
+
+describe('updateTeamName', () => {
+    const mockFlush = jest.fn();
+    const req = {
+        params: { teamId: '__someTeamUUID__' },
+        body: '__someUpdateTeamNameRequest__',
+        listService: { flush: mockFlush }
+    };
+    let res = { sendStatus: jest.fn() };
+    const next = jest.fn();
+    const headers = '__headers__';
+
+    it('should successfully perform put with data', async () => {
+        User.createHeaders.mockImplementation(() => headers);
+        await updateTeamName(req, res, next);
+
+        expect(infoService.put).toHaveBeenCalledWith(
+            '/team/__someTeamUUID__',
+            '__someUpdateTeamNameRequest__',
+            { headers: headers }
+        );
+        expect(req.listService.flush).toHaveBeenCalledWith('TEAMS');
+        expect(res.sendStatus).toHaveBeenCalledWith(200);
+    });
+
+    it('should catch and log error if put request fails', async () => {
+        infoService.put.mockImplementation(() => Promise.reject());
+        await updateTeamName(req, res, next);
         expect(logError).toHaveBeenCalled();
         expect(next).toHaveBeenCalled();
     });

--- a/server/middleware/team.js
+++ b/server/middleware/team.js
@@ -64,6 +64,24 @@ async function addTeam(req, res, next) {
     }
 }
 
+
+async function updateTeamName(req, res, next) {
+    const logger = getLogger(req.request);
+    const { teamId } = req.params;
+    try {
+        await infoService.put(
+            `/team/${teamId}`,
+            req.body,
+            { headers: User.createHeaders(req.user) }
+        );
+        req.listService.flush('TEAMS');
+        res.sendStatus(200);
+    } catch (error) {
+        logger.error(error);
+        next(error);
+    }
+}
+
 async function returnTeamJson(_, res) {
     const { locals: { team } } = res;
     await res.json(team);
@@ -86,5 +104,6 @@ module.exports = {
     returnTeamJson,
     returnTeamsJson,
     returnTeamMembersJson,
-    addTeam
+    addTeam,
+    updateTeamName
 };

--- a/server/routes/api/teams.js
+++ b/server/routes/api/teams.js
@@ -2,7 +2,7 @@ const router = require('express').Router();
 const {
     getTeam, getTeams, getTeamMembers, getTeamsForUser,
     returnTeamJson, returnTeamsJson, returnTeamMembersJson,
-    addTeam
+    addTeam, updateTeamName
 } = require('../../middleware/team');
 const { protect } = require('../../middleware/auth');
 
@@ -17,5 +17,7 @@ router.get('/:userId/teams', getTeamsForUser, returnTeamsJson);
 router.post('/unit/:unitUUID',
     protect('DCU'),
     addTeam);
+
+router.put('/:teamId', updateTeamName);
 
 module.exports = router;

--- a/server/routes/api/teams.js
+++ b/server/routes/api/teams.js
@@ -18,6 +18,8 @@ router.post('/unit/:unitUUID',
     protect('DCU'),
     addTeam);
 
-router.put('/:teamId', updateTeamName);
+router.put('/:teamId',
+    protect('RENAME_TEAM'),
+    updateTeamName);
 
 module.exports = router;

--- a/src/shared/models/constants.ts
+++ b/src/shared/models/constants.ts
@@ -80,3 +80,5 @@ export const TEAM_CREATION_FAILURE_NAME_ALREADY_EXISTS = 'The team name already 
 export const TEAM_CREATION_FAILURE_UNKNOWN_ERROR = 'Something went wrong when adding the team';
 export const LOAD_NOMINATED_CONTACTS_ERROR_DESCRIPTION = 'There was an error retrieving the list of nominated contacts.  Please try refreshing the page.';
 export const DELETE_NOMINATED_CONTACTS_ERROR_DESCRIPTION = 'There was an error deleting the nominated contact. Please try refreshing the page.';
+export const TEAM_RENAME_FAILED_NAME_ALREADY_EXISTS = 'A team with that name already exists. Please try a different name.';
+export const TEAM_RENAME_FAILED_UNKNOWN_ERROR = 'There was a problem renaming the team. Contact the service desk.';

--- a/src/shared/models/team.ts
+++ b/src/shared/models/team.ts
@@ -2,7 +2,7 @@ import Permission from './permission';
 
 export default interface Team {
     active: boolean;
-    displayName?: string;
+    displayName: string;
     letterName: string;
     permissions: Permission[];
     type: string;

--- a/src/shared/pages/team/addToTeam/__tests__/__snapshots__/addToTeam.spec.tsx.snap
+++ b/src/shared/pages/team/addToTeam/__tests__/__snapshots__/addToTeam.spec.tsx.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`when the addToTeam component is mounted should initially render null before the team name is returned 1`] = `"<div><a class=\\"govuk-back-link\\" href=\\"/team-view/__teamId__\\">Back</a><div class=\\"govuk-grid-row\\"><div class=\\"govuk-grid-column-two-thirds-from-desktop\\"><table class=\\"govuk-table\\"><caption class=\\"govuk-table__caption\\">Users to be added</caption><tbody class=\\"govuk-table__body\\"><tr class=\\"govuk-table__row\\"><th scope=\\"row\\" class=\\"govuk-table__header\\">__user1__</th><td class=\\"govuk-table__cell\\"><a class=\\"govuk-link\\" href=\\"#\\">Remove<span class=\\"govuk-visually-hidden\\"> user</span></a></td></tr><tr class=\\"govuk-table__row\\"><th scope=\\"row\\" class=\\"govuk-table__header\\">__user2__</th><td class=\\"govuk-table__cell\\"><a class=\\"govuk-link\\" href=\\"#\\">Remove<span class=\\"govuk-visually-hidden\\"> user</span></a></td></tr></tbody></table></div></div><button type=\\"submit\\" class=\\"govuk-button view-team-button\\">Add selected users</button></div>"`;
-
 exports[`when the addToTeam component is mounted should render with default props 1`] = `
 <div>
   <a

--- a/src/shared/pages/team/addToTeam/__tests__/addToTeam.spec.tsx
+++ b/src/shared/pages/team/addToTeam/__tests__/addToTeam.spec.tsx
@@ -106,18 +106,6 @@ describe('when the addToTeam component is mounted', () => {
         });
     });
 
-    it('should initially render null before the team name is returned', async () => {
-        getTeamSpy.mockReturnValueOnce(Promise.resolve({
-            active: true,
-            displayName: undefined,
-            letterName: '__letterName__',
-            permissions: [],
-            type: '__type__'
-        }));
-        mockState.teamName = undefined;
-        const wrapper: RenderResult = renderComponent();
-        expect(wrapper.container.outerHTML).toMatchSnapshot();
-    });
     it('should display an error if the call to retrieve the team fails', async () => {
         expect.assertions(1);
         getTeamSpy.mockImplementation(() => Promise.reject('error'));

--- a/src/shared/pages/team/editTeam/__tests__/__snapshots__/editTeam.spec.tsx.snap
+++ b/src/shared/pages/team/editTeam/__tests__/__snapshots__/editTeam.spec.tsx.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`when the editTeam component is mounted should render with default props 1`] = `
+<div>
+  <div
+    class="govuk-grid-row"
+  >
+    <div
+      class="govuk-grid-column-two-thirds-from-desktop"
+    >
+      <a
+        class="govuk-back-link"
+        href="/team-view/__teamId__"
+      >
+        Back
+      </a>
+      <h1
+        class="govuk-heading-xl"
+      >
+        Edit 
+        
+      </h1>
+    </div>
+  </div>
+  <div
+    class="govuk-grid-row"
+  >
+    <div
+      class="govuk-grid-column-two-thirds-from-desktop"
+    >
+      <form
+        method="POST"
+      >
+        <input
+          name="_csrf"
+          type="hidden"
+          value=""
+        />
+        <div
+          class="govuk-form-group"
+        >
+          <label
+            class="govuk-label govuk-label--s"
+            for="newTeamName"
+            id="newTeamName-label"
+          >
+            New team name
+          </label>
+          <input
+            class="govuk-input"
+            id="newTeamName"
+            name="newTeamName"
+            type="text"
+            value=""
+          />
+        </div>
+        <div
+          class="govuk-form-group"
+        >
+          <button
+            class="govuk-button"
+            type="submit"
+          >
+            Update
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+`;

--- a/src/shared/pages/team/editTeam/__tests__/editTeam.spec.tsx
+++ b/src/shared/pages/team/editTeam/__tests__/editTeam.spec.tsx
@@ -1,0 +1,179 @@
+
+import React from 'react';
+import { match, MemoryRouter } from 'react-router-dom';
+import { createBrowserHistory, History, Location } from 'history';
+import { act, render, RenderResult, wait, fireEvent, waitForElement } from '@testing-library/react';
+import EditTeam from '../editTeam';
+import * as TeamsService from '../../../../services/teamsService';
+import { GENERAL_ERROR_TITLE, LOAD_TEAM_ERROR_DESCRIPTION, TEAM_RENAME_FAILED_NAME_ALREADY_EXISTS, TEAM_RENAME_FAILED_UNKNOWN_ERROR } from '../../../../models/constants';
+import * as useError from '../../../../hooks/useError';
+import { State } from '../state';
+
+let match: match<any>;
+let history: History<any>;
+let location: Location;
+let mockState: State;
+let wrapper: RenderResult;
+
+const useReducerSpy = jest.spyOn(React, 'useReducer');
+const reducerDispatch = jest.fn();
+const useErrorSpy = jest.spyOn(useError, 'default');
+const addFormErrorSpy = jest.fn();
+const clearErrorsSpy = jest.fn();
+const setMessageSpy = jest.fn();
+
+const renderComponent = () => render(
+    <MemoryRouter>
+        <EditTeam history={history} location={location} match={match}></EditTeam>
+    </MemoryRouter>
+);
+
+jest.spyOn(TeamsService, 'getTeam').mockImplementation(() => Promise.resolve({
+    active: true,
+    displayName: '__displayName__',
+    letterName: '__letterName__',
+    permissions: [],
+    type: '__type__'
+}));
+jest.spyOn(TeamsService, 'updateTeamName').mockImplementation(() => Promise.resolve(200));
+
+beforeEach(() => {
+    history = createBrowserHistory();
+    match = {
+        isExact: true,
+        params: { teamId: '__teamId__' },
+        path: '',
+        url: ''
+    };
+    location = {
+        hash: '',
+        key: '',
+        pathname: '',
+        search: '',
+        state: {}
+    };
+    mockState = {
+        currentDisplayName: '',
+        newDisplayName: ''
+    };
+    useReducerSpy.mockImplementation(() => [mockState, reducerDispatch]);
+    useErrorSpy.mockImplementation(() => [{}, addFormErrorSpy, clearErrorsSpy, setMessageSpy]);
+    history.push = jest.fn();
+    reducerDispatch.mockReset();
+    addFormErrorSpy.mockReset();
+    clearErrorsSpy.mockReset();
+    setMessageSpy.mockReset();
+    act(() => {
+        wrapper = renderComponent();
+    });
+});
+
+describe('when the editTeam component is mounted', () => {
+    it('should render with default props', async () => {
+        expect.assertions(1);
+
+        await wait(() => {
+            expect(wrapper.container).toMatchSnapshot();
+        });
+    });
+
+    describe('and the getTeam service fails', () => {
+        beforeAll(() => {
+            jest.spyOn(TeamsService, 'getTeam').mockImplementationOnce(() => Promise.reject());
+        });
+
+        it('should set the error state', () => {
+            expect(setMessageSpy).toHaveBeenCalledWith({ description: LOAD_TEAM_ERROR_DESCRIPTION, title: GENERAL_ERROR_TITLE });
+        });
+    });
+});
+
+describe('when the name is entered', () => {
+    it('should be persisted in the page state', async () => {
+        expect.assertions(1);
+
+        const nameElement = await waitForElement(async () => {
+            return await wrapper.findByLabelText('New team name');
+        });
+
+        fireEvent.change(nameElement, { target: { name: 'newTeamName', value: '__displayTitle__' } });
+
+        await wait(() => {
+            expect(reducerDispatch).toHaveBeenCalledWith({ type: 'SetNewTeamName', payload: '__displayTitle__' });
+        });
+    });
+});
+
+describe('when the submit button is clicked', () => {
+    describe('and the data is filled in', () => {
+
+        beforeEach(async () => {
+            mockState.currentDisplayName = '__currentDisplayName__';
+            mockState.newDisplayName = '__newDisplayName__';
+
+            const submitButton = await waitForElement(async () => {
+                return await wrapper.findByText('Update');
+            });
+
+            fireEvent.click(submitButton);
+        });
+
+        describe('and the updateTeamName service call is successful', () => {
+            it('should redirect to the team view page', async () => {
+                expect.assertions(1);
+
+                await wait(() => {
+                    expect(history.push).toHaveBeenCalledWith('/team-view/__teamId__', { successMessage: 'Team name changed from __currentDisplayName__ to __newDisplayName__.' });
+                });
+            });
+
+            it('should call the begin update action', async () => {
+                expect.assertions(1);
+
+                await wait(() => {
+                    expect(clearErrorsSpy).toHaveBeenCalled();
+                });
+            });
+        });
+
+        describe('and the updateTeamName service call fails', () => {
+            beforeAll(() => {
+                jest.spyOn(TeamsService, 'updateTeamName').mockImplementationOnce(() => Promise.reject({ response: { status: 500 } }));
+            });
+
+            it('should set the error state', () => {
+                expect(setMessageSpy).toHaveBeenCalledWith({ description: TEAM_RENAME_FAILED_UNKNOWN_ERROR, title: GENERAL_ERROR_TITLE });
+            });
+
+            it('should call the begin submit action', () => {
+                expect(clearErrorsSpy).toHaveBeenCalled();
+            });
+        });
+        describe('and the updateTeamName service call fails with a 409', () => {
+            beforeAll(() => {
+                jest.spyOn(TeamsService, 'updateTeamName').mockImplementationOnce(() => Promise.reject({ response: { status: 409 } }));
+            });
+
+            it('should set the error state', () => {
+                expect(setMessageSpy).toHaveBeenCalledWith({ description: TEAM_RENAME_FAILED_NAME_ALREADY_EXISTS, title: GENERAL_ERROR_TITLE });
+            });
+        });
+    });
+    describe('and the data is not filled in', () => {
+        beforeEach(async () => {
+            const submitButton = await waitForElement(async () => {
+                return await wrapper.findByText('Update');
+            });
+
+            fireEvent.click(submitButton);
+        });
+
+        it('should call the begin submit action', () => {
+            expect(clearErrorsSpy).toHaveBeenCalled();
+        });
+
+        it('should set the error state', () => {
+            expect(addFormErrorSpy).toHaveBeenNthCalledWith(1, { key: 'newDisplayName', value: 'The new team name is required' });
+        });
+    });
+});

--- a/src/shared/pages/team/editTeam/__tests__/reducer.spec.tsx
+++ b/src/shared/pages/team/editTeam/__tests__/reducer.spec.tsx
@@ -1,0 +1,26 @@
+import { initialState } from '../initialState';
+import { reducer } from '../reducer';
+
+describe('Given the SetCurrentTeamName action is dispatched', () => {
+    it('it will set the currentDisplayName', () => {
+        const state = reducer(initialState, { type: 'SetCurrentTeamName', payload: '__someTeamName__' });
+
+        const expectedState = {
+            currentDisplayName: '__someTeamName__',
+            newDisplayName: ''
+        };
+        expect(state).toStrictEqual(expectedState);
+    });
+});
+
+describe('Given the SetNewTeamName action is dispatched', () => {
+    it('it will set the newDisplayName', () => {
+        const state = reducer(initialState, { type: 'SetNewTeamName', payload: '__someTeamName__' });
+
+        const expectedState = {
+            currentDisplayName: '',
+            newDisplayName: '__someTeamName__'
+        };
+        expect(state).toStrictEqual(expectedState);
+    });
+});

--- a/src/shared/pages/team/editTeam/actions.ts
+++ b/src/shared/pages/team/editTeam/actions.ts
@@ -1,0 +1,13 @@
+export type SetCurrentTeamName = {
+    payload: string
+    type: 'SetCurrentTeamName';
+};
+
+export type SetNewTeamName = {
+    payload: string
+    type: 'SetNewTeamName';
+};
+
+export type Action =
+    SetCurrentTeamName |
+    SetNewTeamName;

--- a/src/shared/pages/team/editTeam/editTeam.tsx
+++ b/src/shared/pages/team/editTeam/editTeam.tsx
@@ -1,0 +1,112 @@
+import React, { useEffect, useReducer } from 'react';
+import { Link, RouteComponentProps } from 'react-router-dom';
+import Text from '../../../common/components/forms/text';
+import ErrorSummary from '../../../common/components/errorSummary';
+import useError from '../../../hooks/useError';
+import { reducer } from './reducer';
+import { initialState } from './initialState';
+import { ApplicationConsumer } from '../../../contexts/application';
+import { object, string } from 'yup';
+import { validate } from '../../../validation';
+import { getTeam, updateTeamName } from '../../../services/teamsService';
+import ErrorMessage from '../../..//models/errorMessage';
+import { GENERAL_ERROR_TITLE, LOAD_TEAM_ERROR_DESCRIPTION, TEAM_RENAME_FAILED_NAME_ALREADY_EXISTS, TEAM_RENAME_FAILED_UNKNOWN_ERROR, VALIDATION_ERROR_TITLE } from '../../../models/constants';
+
+interface MatchParams {
+    teamId: string;
+}
+
+interface EditTeamProps extends RouteComponentProps<MatchParams> {
+    csrfToken?: string;
+}
+
+const validationSchema = object({
+    newDisplayName: string()
+        .required()
+        .label('new team name')
+});
+
+const EditTeam: React.FC<EditTeamProps> = ({ csrfToken, history, match }) => {
+
+    const [pageError, addFormError, clearErrors, setErrorMessage] = useError('', VALIDATION_ERROR_TITLE);
+    const [state, dispatch] = useReducer(reducer, initialState);
+
+    const { params: { teamId } } = match;
+
+    useEffect(() => {
+        getTeam(teamId)
+            .then(team => {
+                return dispatch({ type: 'SetCurrentTeamName', payload: team.displayName });
+            })
+            .catch(() => {
+                setErrorMessage(new ErrorMessage(LOAD_TEAM_ERROR_DESCRIPTION, GENERAL_ERROR_TITLE));
+            });
+    }, []);
+
+    const handleSubmit = (event: React.FormEvent) => {
+        event.preventDefault();
+        clearErrors();
+
+        if (validate(validationSchema, state, addFormError)) {
+            updateTeamName(teamId, state.newDisplayName).then(() => {
+                history.push(`/team-view/${teamId}`, { successMessage: `Team name changed from ${state.currentDisplayName} to ${state.newDisplayName}.` });
+            }).catch((error) => {
+                if (error && error.response && error.response.status === 409) {
+                    setErrorMessage(
+                        new ErrorMessage(TEAM_RENAME_FAILED_NAME_ALREADY_EXISTS, GENERAL_ERROR_TITLE)
+                    );
+                } else {
+                    setErrorMessage(new ErrorMessage(TEAM_RENAME_FAILED_UNKNOWN_ERROR, GENERAL_ERROR_TITLE));
+                }
+            });
+        }
+    };
+
+    return (
+        <>
+            <div className="govuk-grid-row">
+                <div className="govuk-grid-column-two-thirds-from-desktop">
+                    <Link to={`/team-view/${teamId}`} className="govuk-back-link">Back</Link>
+                    <ErrorSummary
+                        pageError={pageError}
+                    />
+                    <h1 className="govuk-heading-xl">
+                        Edit {state.currentDisplayName}
+                    </h1>
+                </div>
+            </div>
+
+            <div className="govuk-grid-row">
+                <div className="govuk-grid-column-two-thirds-from-desktop">
+                    <form method="POST" onSubmit={handleSubmit}>
+                        <input type="hidden" name="_csrf" value={csrfToken} />
+                        <Text
+                            label="New team name"
+                            name="newTeamName"
+                            type="text"
+                            updateState={
+                                ({ value }) => dispatch({ type: 'SetNewTeamName', payload: value as string })
+                            }
+                            value={state.newDisplayName}
+                        />
+
+                        <div className="govuk-form-group">
+                            <button type="submit" className="govuk-button">Update</button>
+                        </div>
+
+                    </form>
+                </div>
+            </div>
+        </>
+    );
+};
+
+const WrappedEditTeam = (routeProps: RouteComponentProps<MatchParams>) => (
+    <ApplicationConsumer>
+        {({ csrf }) => (
+            <EditTeam csrfToken={csrf} {...routeProps} />
+        )}
+    </ApplicationConsumer>
+);
+
+export default WrappedEditTeam;

--- a/src/shared/pages/team/editTeam/initialState.ts
+++ b/src/shared/pages/team/editTeam/initialState.ts
@@ -1,0 +1,6 @@
+import { State } from './state';
+
+export const initialState: State = {
+    currentDisplayName: '',
+    newDisplayName: ''
+};

--- a/src/shared/pages/team/editTeam/reducer.ts
+++ b/src/shared/pages/team/editTeam/reducer.ts
@@ -1,0 +1,17 @@
+import { State } from './state';
+import { Action } from './actions';
+
+export const reducer = (state: State, action: Action): State => {
+    switch (action.type) {
+        case 'SetCurrentTeamName':
+            return {
+                ...state,
+                currentDisplayName: action.payload
+            };
+        case 'SetNewTeamName':
+            return {
+                ...state,
+                newDisplayName: action.payload
+            };
+    }
+};

--- a/src/shared/pages/team/editTeam/state.ts
+++ b/src/shared/pages/team/editTeam/state.ts
@@ -1,0 +1,4 @@
+export interface State {
+    currentDisplayName: string,
+    newDisplayName: string
+}

--- a/src/shared/pages/team/teamView/__tests__/__snapshots__/teamView.spec.tsx.snap
+++ b/src/shared/pages/team/teamView/__tests__/__snapshots__/teamView.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`when the teamView component is mounted should render with default props 1`] = `
+exports[`when the teamView component is mounted with RENAME_TEAM role should render with default props 1`] = `
 <div>
   <div
     class="govuk-form-group"
@@ -96,7 +96,121 @@ exports[`when the teamView component is mounted should render with default props
         Add team members
       </button>
       <button
-        class="govuk-button govuk-button--secondary  manage-nominated-contacts-button"
+        class="govuk-button govuk-!-margin-right-1 govuk-button--secondary manage-nominated-contacts-button"
+        data-module="govuk-button"
+        type="submit"
+      >
+        Manage nominated contacts
+      </button>
+      <button
+        class="govuk-button govuk-button--secondary"
+        data-module="govuk-button"
+        type="submit"
+      >
+        Edit Team
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`when the teamView component is mounted without RENAME_TEAM role should render with default props 1`] = `
+<div>
+  <div
+    class="govuk-form-group"
+  >
+    <a
+      class="govuk-back-link"
+      href="/team-search"
+    >
+      Back
+    </a>
+    <div>
+      <h1
+        class="govuk-heading-xl"
+      >
+        View and remove team members
+      </h1>
+      <h2
+        class="govuk-heading-l"
+      >
+        Team: __teamName__
+      </h2>
+      <div>
+        <table
+          class="govuk-table"
+        >
+          <thead
+            class="govuk-table__head"
+          >
+            <tr
+              class="govuk-table__row"
+            >
+              <th
+                class="govuk-table__header"
+                scope="col"
+              >
+                Team members
+              </th>
+              <th
+                class="govuk-table__header"
+                scope="col"
+              >
+                Action
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            class="govuk-table__body"
+          >
+            <tr
+              class="govuk-table__row"
+            >
+              <td
+                class="govuk-table__cell"
+              >
+                __user1__
+              </td>
+              <td
+                class="govuk-table__cell"
+              >
+                <a
+                  href="#"
+                >
+                  Remove
+                </a>
+              </td>
+            </tr>
+            <tr
+              class="govuk-table__row"
+            >
+              <td
+                class="govuk-table__cell"
+              >
+                __user2__
+              </td>
+              <td
+                class="govuk-table__cell"
+              >
+                <a
+                  href="#"
+                >
+                  Remove
+                </a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <button
+        class="govuk-button govuk-!-margin-right-1 add-team-members-button"
+        data-module="govuk-button"
+        type="submit"
+      >
+        Add team members
+      </button>
+      <button
+        class="govuk-button govuk-!-margin-right-1 govuk-button--secondary manage-nominated-contacts-button"
         data-module="govuk-button"
         type="submit"
       >

--- a/src/shared/pages/team/teamView/teamView.tsx
+++ b/src/shared/pages/team/teamView/teamView.tsx
@@ -13,12 +13,15 @@ import ErrorSummary from '../../../common/components/errorSummary';
 import ErrorMessage from '../../../models/errorMessage';
 import useError from '../../../hooks/useError';
 import { Link } from 'react-router-dom';
+import { ApplicationConsumer, ApplicationState } from '../../../contexts/application';
 
 interface MatchParams {
     teamId: string;
 }
 
-type TeamMembersProps = RouteComponentProps<MatchParams>;
+interface TeamMembersProps extends RouteComponentProps<MatchParams> {
+    hasRole: (role: string) => boolean;
+}
 
 const onAddTeamMembersAddClick = (history: History, teamId: string) => {
     history.push(`/team/${teamId}/add-users`);
@@ -28,8 +31,11 @@ const onAddNominatedContactClick = (history: History, teamId: string) => {
     history.push(`/team/${teamId}/manage-nominated-contacts`);
 };
 
-const TeamView: React.FC<TeamMembersProps> = ({ history, match }) => {
+const onEditTeamAddClick = (history: History, teamId: string) => {
+    history.push(`/team/${teamId}/edit`);
+};
 
+const TeamView: React.FC<TeamMembersProps> = ({ history, match, hasRole }) => {
     const [pageError, , clearErrors, setErrorMessage] = useError();
     const [state, dispatch] = React.useReducer<Reducer<State, Action>>(reducer, initialState);
 
@@ -118,10 +124,22 @@ const TeamView: React.FC<TeamMembersProps> = ({ history, match }) => {
                         </div>
                 }
                 <button type="submit" className="govuk-button govuk-!-margin-right-1 add-team-members-button" data-module="govuk-button" onClick={() => onAddTeamMembersAddClick(history, teamId as string)}>Add team members</button>
-                <button type="submit" className="govuk-button govuk-button--secondary  manage-nominated-contacts-button" data-module="govuk-button" onClick={() => onAddNominatedContactClick(history, teamId as string)}>Manage nominated contacts</button>
+                <button type="submit" className="govuk-button govuk-!-margin-right-1 govuk-button--secondary manage-nominated-contacts-button" data-module="govuk-button" onClick={() => onAddNominatedContactClick(history, teamId as string)}>Manage nominated contacts</button>
+                {hasRole('RENAME_TEAM') &&
+                    <button type="submit" className="govuk-button govuk-button--secondary" data-module="govuk-button" onClick={() => onEditTeamAddClick(history, teamId)}>Edit Team</button>}
             </div>
         </div>
     );
 };
 
-export default TeamView;
+const WrappedTeamView = (routeProps: RouteComponentProps<MatchParams>) => (
+    <ApplicationConsumer>
+        {
+            ({ hasRole }: ApplicationState) => {
+                return <TeamView {...routeProps} hasRole={hasRole} />;
+            }
+        }
+    </ApplicationConsumer>
+);
+
+export default WrappedTeamView;

--- a/src/shared/router/routes/index.ts
+++ b/src/shared/router/routes/index.ts
@@ -27,6 +27,7 @@ import CampaignsView from '../../pages/list/mpamCampaign/campaignsView';
 import AddCampaign from '../../pages/list/mpamCampaign/addCampaign';
 import AmendCampaign from '../../pages/list/mpamCampaign/amendCampaign';
 import AddTeam from '../../pages/team/addTeam/addTeam';
+import EditTeam from '../../pages/team/editTeam/editTeam';
 
 export interface Route {
     component: React.FunctionComponent | Error;
@@ -95,6 +96,12 @@ const routes = [
         exact: true,
         component: AddUsersToTeam,
         title: 'AddUsersToTeam'
+    },
+    {
+        path: '/team/:teamId/edit',
+        exact: true,
+        component: EditTeam,
+        title: 'EditTeam'
     },
     {
         path: '/add-unit',

--- a/src/shared/services/__tests__/teamsService.spec.ts
+++ b/src/shared/services/__tests__/teamsService.spec.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import {
-    getTeam, getTeams, getTeamMembers, getTeamsForUser, addTeam
+    getTeam, getTeams, getTeamMembers, getTeamsForUser, addTeam, updateTeamName
 } from '../teamsService';
 import Team from '../../models/team';
 import { User } from '../../models/user';
@@ -10,6 +10,7 @@ jest.mock('axios');
 
 let axiosGetSpy: jest.SpyInstance;
 const axiosPostSpy: jest.SpyInstance = jest.spyOn(axios, 'post');
+const axiosPutSpy: jest.SpyInstance = jest.spyOn(axios, 'put');
 
 beforeEach(() => {
     jest.resetAllMocks();
@@ -219,6 +220,36 @@ describe('when the addTeam function is called', () => {
             expect.assertions(1);
 
             await addTeam(team).catch((error: Error) => {
+                expect(error.message).toEqual('__someError__');
+            });
+        });
+    });
+});
+
+describe('when the updateTeamName function is called', () => {
+    const teamId = '__teamId__';
+    const newTeamName = '__newTeamName__';
+
+    describe('and the put request is successful', () => {
+        it('should return a resolved promise', async () => {
+            expect.assertions(1);
+            axiosPutSpy.mockReturnValue(Promise.resolve({ data: {} }));
+
+            await updateTeamName(teamId, newTeamName).then(() => {
+                expect(axiosPutSpy).toHaveBeenCalledWith(
+                    '/api/teams/__teamId__',
+                    { displayName: newTeamName }
+                );
+            });
+        });
+    });
+
+    describe('and the request fails', () => {
+        it('should return a rejected promise with the error', async () => {
+            axiosPutSpy.mockReturnValue(Promise.reject(new Error('__someError__')));
+            expect.assertions(1);
+
+            await updateTeamName(teamId, newTeamName).catch((error: Error) => {
                 expect(error.message).toEqual('__someError__');
             });
         });

--- a/src/shared/services/teamsService.ts
+++ b/src/shared/services/teamsService.ts
@@ -31,3 +31,9 @@ export const addTeam = (team: Team) => new Promise((resolve, reject) => axios
     .then(response => resolve(response.data))
     .catch(reason => reject(reason))
 );
+
+export const updateTeamName = (teamId: string, newDisplayName: string) => new Promise((resolve, reject) => axios
+    .put(`/api/teams/${teamId}`, { displayName: newDisplayName })
+    .then(response => resolve(response.data))
+    .catch(reason => reject(reason))
+);


### PR DESCRIPTION
This change contains the following changes to allow for editing the team name: 

- New button on the `teamView` page to edit the team.
- New `editTeam` page that handles the frontend form to change the name.
- Node server API to talk between the frontend and the java spring boot backend.
- Role based protection on button and express route.