### PR TITLE
    HOCS-2666 Team members list in M:UI doesn't always update

### DIFF
--- a/server/middleware/__tests__/user.spec.js
+++ b/server/middleware/__tests__/user.spec.js
@@ -22,8 +22,9 @@ describe('User middleware addToTeam', () => {
 
     it('should call the post method on the info service', async () => {
         User.createHeaders.mockImplementation(() => headers);
+        req.body = ['__user1__', '__user2__'];
         await addToTeam(req, res, next);
-        expect(infoService.post).toHaveBeenCalledWith(`/users/${userId}/team/${teamId}`, {}, { headers: headers });
+        expect(infoService.post).toHaveBeenCalledWith(`/users/team/${teamId}`, ['__user1__', '__user2__'], { headers: headers });
     });
 
     it('should call the user create headers method', async () => {

--- a/server/middleware/user.js
+++ b/server/middleware/user.js
@@ -3,13 +3,13 @@ const getLogger = require('../libs/logger');
 const User = require('../models/user');
 const { FormSubmissionError } = require('../models/error');
 
-async function addToTeam(req, _, next) {
+async function addUsersToTeam(req, _, next) {
 
     const logger = getLogger(req.request);
-    const { userId, teamId } = req.params;
+    const { teamId } = req.params;
 
     try {
-        await infoService.post(`/users/${userId}/team/${teamId}`, {}, { headers: User.createHeaders(req.user) });
+        await infoService.post(`/users/team/${teamId}`, req.body, { headers: User.createHeaders(req.user) });
         next();
     } catch (error) {
         logger.error(error);
@@ -101,7 +101,7 @@ async function returnUserJson(_, res) {
 }
 
 module.exports = {
-    addToTeam,
+    addToTeam: addUsersToTeam,
     getAllUsers,
     getUser,
     addUser,

--- a/server/routes/api/users.js
+++ b/server/routes/api/users.js
@@ -3,7 +3,7 @@ const { addToTeam, getAllUsers, getUser, addUser, amendUser, removeFromTeam, ret
 const { getTeams, returnTeamsJson } = require('../../middleware/team');
 const { fileMiddleware } = require('../../middleware/file');
 
-router.post('/:userId/team/:teamId', addToTeam, getTeams, returnTeamsJson);
+router.post('/team/:teamId', addToTeam, getTeams, returnTeamsJson);
 
 router.delete('/:userId/team/:teamId', removeFromTeam, getTeams, returnTeamsJson);
 

--- a/src/shared/pages/team/addToTeam/__tests__/addToTeam.spec.tsx
+++ b/src/shared/pages/team/addToTeam/__tests__/addToTeam.spec.tsx
@@ -27,7 +27,7 @@ jest.mock('../../../../services/teamsService', () => ({
 
 jest.mock('../../../../services/usersService', () => ({
     __esModule: true,
-    addUserToTeam: jest.fn().mockReturnValue(Promise.resolve()),
+    addUsersToTeam: jest.fn().mockReturnValue(Promise.resolve()),
     getUsers: jest.fn().mockReturnValue(Promise.resolve(
         [{
             label: '__user1__',
@@ -40,7 +40,7 @@ jest.mock('../../../../services/usersService', () => ({
 }));
 
 const getTeamSpy = jest.spyOn(TeamsService, 'getTeam');
-const addUsersToTeamSpy = jest.spyOn(UsersService, 'addUserToTeam');
+const addUsersToTeamSpy = jest.spyOn(UsersService, 'addUsersToTeam');
 const getUsersSpy = jest.spyOn(UsersService, 'getUsers');
 const useReducerSpy = jest.spyOn(React, 'useReducer');
 const reducerDispatch = jest.fn();
@@ -139,44 +139,31 @@ describe('when the submit button is clicked', () => {
         });
     });
 
-    it('should call the service and dispach actions for the selected options', async () => {
+    it('should call the service and dispatch actions for the selected options', async () => {
         await wait(async () => {
             const submitButton = getByText(wrapper.container, 'Add selected users');
             fireEvent.click(submitButton);
         });
 
         await wait(async () => {
-            expect(addUsersToTeamSpy).nthCalledWith(1, {
-                label: '__user1__',
-                value: '__userId1__'
-            }, '__teamId__');
-            expect(addUsersToTeamSpy).nthCalledWith(2, {
-                label: '__user2__',
-                value: '__userId2__'
-            }, '__teamId__');
+            expect(addUsersToTeamSpy).nthCalledWith(1, [
+                { 'label': '__user1__', 'value': '__userId1__' },
+                { 'label': '__user2__', 'value': '__userId2__' }],
+            '__teamId__');
             expect(clearErrorsSpy).toBeCalled();
             expect(reducerDispatch).nthCalledWith(1, {
-                type: 'RemoveFromSelection', payload: {
-                    label: '__user1__',
-                    value: '__userId1__'
-                }
-            });
-            expect(reducerDispatch).nthCalledWith(2, {
-                type: 'RemoveFromSelection', payload: {
-                    label: '__user2__',
-                    value: '__userId2__'
-                }
+                type: 'RemoveAllFromSelection'
             });
         });
     });
 
     it('should display errors for each erroring team member add request', async () => {
-        expect.assertions(2);
+        expect.assertions(1);
         addUsersToTeamSpy.mockImplementation(() => Promise.reject({
-            userToAdd: {
+            usersToAdd: [{
                 label: '__label__',
                 value: '__value__'
-            }
+            }]
         }));
 
         await wait(() => {
@@ -185,7 +172,6 @@ describe('when the submit button is clicked', () => {
         });
 
         expect(addFormErrorSpy).nthCalledWith(1, { key: '__value__', value: '__label__' });
-        expect(addFormErrorSpy).nthCalledWith(2, { key: '__value__', value: '__label__' });
     });
 
     it('should set an error when no users are selected', async () => {

--- a/src/shared/pages/team/addToTeam/actions.ts
+++ b/src/shared/pages/team/addToTeam/actions.ts
@@ -15,9 +15,13 @@ export type SetTeamName = {
     type: 'SetTeamName';
     payload?: string;
 };
+export type RemoveAllFromSelection = {
+    type: 'RemoveAllFromSelection';
+};
 
 export type Action =
     AddToSelection |
     ClearSelectedUser |
     RemoveContact |
-    SetTeamName;
+    SetTeamName |
+    RemoveAllFromSelection;

--- a/src/shared/pages/team/addToTeam/addToTeam.tsx
+++ b/src/shared/pages/team/addToTeam/addToTeam.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useCallback, Reducer } from 'react';
 import { RouteComponentProps } from 'react-router';
 import { getTeam } from '../../../services/teamsService';
-import { addUserToTeam, getUsers, AddUserError } from '../../../services/usersService';
+import { addUsersToTeam, getUsers, AddUserError } from '../../../services/usersService';
 import TypeAhead from '../../../common/components/typeAhead';
 import ErrorSummary from '../../../common/components/errorSummary';
 import Item from '../../../models/item';
@@ -34,17 +34,15 @@ const AddToTeam: React.FC<AddToTeamProps> = ({ history, match }) => {
             return;
         }
 
-        Promise.all(state.selectedUsers.map(user =>
-            addUserToTeam(user, teamId)
-                .then(() => dispatch({ type: 'RemoveFromSelection', payload: user }))
-                .catch((error: AddUserError) => {
-                    const { userToAdd: { label, value } } = error;
-                    addFormError({ key: value, value: label });
-                    throw error;
-                })
-        )).then(() => {
-            history.push(`/team-view/${teamId}`, { successMessage: ADD_USER_SUCCESS });
-        }).catch(() => { });
+        addUsersToTeam(state.selectedUsers, teamId)
+            .then(() => dispatch({ type: 'RemoveAllFromSelection' }))
+            .catch((error: AddUserError) => {
+                error.usersToAdd.map(({ label, value }) => addFormError({ key: value, value: label }));
+                throw error;
+            })
+            .then(() => {
+                history.push(`/team-view/${teamId}`, { successMessage: ADD_USER_SUCCESS });
+            }).catch(() => { });
     };
 
     const onSelectedUserChange = useCallback((selectedUser: Item) => {

--- a/src/shared/pages/team/addToTeam/reducer.ts
+++ b/src/shared/pages/team/addToTeam/reducer.ts
@@ -9,6 +9,8 @@ export const reducer = (state: State, action: Action): State => {
             return { ...state, selectedUser: '' };
         case 'RemoveFromSelection':
             return { ...state, selectedUsers: [...state.selectedUsers.filter(user => user.value !== action.payload.value)] };
+        case 'RemoveAllFromSelection':
+            return { ...state, selectedUsers: [...state.selectedUsers = []] };
         case 'SetTeamName':
             return { ...state, teamName: action.payload };
     }

--- a/src/shared/pages/team/teamView/__tests__/teamView.spec.tsx
+++ b/src/shared/pages/team/teamView/__tests__/teamView.spec.tsx
@@ -37,7 +37,7 @@ jest.mock('../../../../services/teamsService', () => ({
 
 jest.mock('../../../../services/usersService', () => ({
     __esModule: true,
-    addUserToTeam: jest.fn().mockReturnValue(Promise.resolve()),
+    addUsersToTeam: jest.fn().mockReturnValue(Promise.resolve()),
     deleteUserFromTeam: jest.fn().mockReturnValue(Promise.resolve()),
     getUsers: jest.fn().mockReturnValue(Promise.resolve({
         data: [{

--- a/src/shared/pages/user/addTeamToUser/__tests__/addTeamToUser.spec.tsx
+++ b/src/shared/pages/user/addTeamToUser/__tests__/addTeamToUser.spec.tsx
@@ -38,7 +38,7 @@ jest.mock('../../../../services/teamsService', () => ({
 }));
 jest.mock('../../../../services/usersService', () => ({
     __esModule: true,
-    addUserToTeam: jest.fn().mockReturnValue(Promise.resolve()),
+    addUsersToTeam: jest.fn().mockReturnValue(Promise.resolve()),
     getUser: jest.fn().mockReturnValue(Promise.resolve({
         label: '__user__',
         value: '__userId__'
@@ -46,7 +46,7 @@ jest.mock('../../../../services/usersService', () => ({
 }));
 
 const getTeamsSpy = jest.spyOn(TeamsService, 'getTeams');
-const addUserToTeamSpy = jest.spyOn(UsersService, 'addUserToTeam');
+const addUserToTeamSpy = jest.spyOn(UsersService, 'addUsersToTeam');
 const getUserSpy = jest.spyOn(UsersService, 'getUser');
 const useReducerSpy = jest.spyOn(React, 'useReducer');
 const reducerDispatch = jest.fn();
@@ -187,14 +187,14 @@ describe('when the submit button is clicked', () => {
         });
 
         await wait(async () => {
-            expect(addUserToTeamSpy).nthCalledWith(1, {
+            expect(addUserToTeamSpy).nthCalledWith(1, [{
                 label: 'd',
                 value: '__user__'
-            }, '__teamId1__');
-            expect(addUserToTeamSpy).nthCalledWith(2, {
+            }], '__teamId1__');
+            expect(addUserToTeamSpy).nthCalledWith(2, [{
                 label: 'd',
                 value: '__user__'
-            }, '__teamId2__');
+            }], '__teamId2__');
             expect(clearErrorsSpy).toBeCalled();
         });
     });

--- a/src/shared/pages/user/addTeamToUser/addTeamToUser.tsx
+++ b/src/shared/pages/user/addTeamToUser/addTeamToUser.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
 import { RouteComponentProps } from 'react-router';
-import { addUserToTeam, getUser } from '../../../services/usersService';
+import { addUsersToTeam, getUser } from '../../../services/usersService';
 import Item from '../../../models/item';
 import { ADD_USER_ERROR_DESCRIPTION, ADD_USER_ERROR_TITLE, ADD_USER_TO_TEAM_SUCCESS, EMPTY_TEAMS_SUBMIT_ERROR_DESCRIPTION, EMPTY_TEAMS_SUBMIT_ERROR_TITLE, GENERAL_ERROR_TITLE, LOAD_TEAMS_ERROR_DESCRIPTION, LOAD_USER_ERROR_DESCRIPTION } from '../../../models/constants';
 import useError from '../../../hooks/useError';
@@ -51,7 +51,7 @@ const AddTeamToUser: React.FC<AddToTeamProps> = ({ history, match }) => {
             selectedTeams.forEach((team) => {
                 const user = state.user;
                 if (user !== undefined) {
-                    addUserToTeam({ label: user.username, value: user.id }, team.value)
+                    addUsersToTeam([{ label: user.username, value: user.id }], team.value)
                         .then(() => dispatch({ type: 'RemoveFromSelectedTeams', payload: team }))
                         .catch(() => {
                             setErrorMessage(new ErrorMessage(ADD_USER_ERROR_TITLE, ADD_USER_ERROR_DESCRIPTION));

--- a/src/shared/pages/user/userView/__tests__/userView.spec.tsx
+++ b/src/shared/pages/user/userView/__tests__/userView.spec.tsx
@@ -28,7 +28,7 @@ jest.mock('../../../../services/teamsService', () => ({
 
 jest.mock('../../../../services/usersService', () => ({
     __esModule: true,
-    addUserToTeam: jest.fn().mockReturnValue(Promise.resolve()),
+    addUsersToTeam: jest.fn().mockReturnValue(Promise.resolve()),
     deleteUserFromTeam: jest.fn().mockReturnValue(Promise.resolve()),
     getUser: jest.fn().mockReturnValue(Promise.resolve(
         {

--- a/src/shared/services/__tests__/usersService.spec.ts
+++ b/src/shared/services/__tests__/usersService.spec.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { getUsers, addUserToTeam, AddUserError, deleteUserFromTeam, addUser, updateUser } from '../usersService';
+import { getUsers, addUsersToTeam, AddUserError, deleteUserFromTeam, addUser, updateUser } from '../usersService';
 import { User } from '../../models/user';
 
 jest.mock('axios');
@@ -87,7 +87,7 @@ describe('when the addUserToTeam method is called', () => {
         it('should return a resolved promise with the users collection', async () => {
             expect.assertions(2);
 
-            await addUserToTeam({ label: '__user1__', value: '__userId1__' }, '__teamId__').then((payload: User[]) => {
+            await addUsersToTeam([{ label: '__user1__', value: '__userId1__' }], '__teamId__').then((payload: User[]) => {
                 expect(axios.post).toHaveBeenCalledTimes(1);
                 expect(payload).toStrictEqual({ label: '__user1__', value: '__userId1__' });
             });
@@ -99,10 +99,16 @@ describe('when the addUserToTeam method is called', () => {
             jest.spyOn(axios, 'post').mockReturnValue(Promise.reject(new Error('__error__')));
             expect.assertions(3);
 
-            await addUserToTeam({ label: '__user1__', value: '__userId1__' }, '__teamId__').catch((error: AddUserError) => {
+            await addUsersToTeam([
+                { label: '__user1__', value: '__userId1__' },
+                { label: '__user2__', value: '__userId2__' }
+            ], '__teamId__').catch((error: AddUserError) => {
                 expect(axios.post).toHaveBeenCalledTimes(1);
                 expect(error.message).toEqual('__error__');
-                expect(error.userToAdd).toStrictEqual({ label: '__user1__', value: '__userId1__' });
+                expect(error.usersToAdd).toStrictEqual([
+                    { label: '__user1__', value: '__userId1__' },
+                    { label: '__user2__', value: '__userId2__' }
+                ]);
             });
         });
     });

--- a/src/shared/services/usersService.ts
+++ b/src/shared/services/usersService.ts
@@ -4,10 +4,10 @@ import Item from '../models/item';
 import UpdateRequest from '../pages/user/userAmend/updateRequest';
 
 export class AddUserError extends Error {
-    userToAdd: Item;
-    constructor(message: string, userToAdd: Item) {
+    usersToAdd: Array<Item>;
+    constructor(message: string, usersToAdd: Array<Item>) {
         super(message);
-        this.userToAdd = userToAdd;
+        this.usersToAdd = usersToAdd;
     }
 }
 
@@ -27,11 +27,14 @@ export const getUsers = () => new Promise((resolve, reject) => axios
     .catch(reason => reject(reason))
 );
 
-export const addUserToTeam = (user: Item, teamId: string) => new Promise((resolve, reject) => axios
-    .post(`/api/users/${user.value}/team/${teamId}`)
-    .then(response => resolve(response.data))
-    .catch(reason => reject(new AddUserError(reason.message, user)))
-);
+export const addUsersToTeam = (users: Array<Item>, teamId: string) => new Promise((resolve, reject) => {
+    const usersUuids = users.map(user => user.value);
+    console.log(`userUuids ${usersUuids}`);
+    axios
+        .post(`/api/users/team/${teamId}`, usersUuids)
+        .then(response => resolve(response.data))
+        .catch(reason => reject(new AddUserError(reason.message, users)));
+});
 
 export const deleteUserFromTeam = (userId: string, teamId: string) => new Promise((resolve, reject) => axios
     .delete(`/api/users/${userId}/team/${teamId}`)


### PR DESCRIPTION
    Removing the caching fixes one cause, but another issue exists where
    adding several users at once creates duplicate groups in keycloak.

    Currently batches of users are added by multiple calls from the MUI,
    this change batches them into a list to handle them more cleanly and
    address the issue above.

    * Remove caching on getUserForTeam in UserService
    * Process adding of users in batch