### PR TITLE
HOCS-1983 Allow custom redirectURL on log out

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -18,7 +18,8 @@ const config = {
                 serviceLink: '/',
                 logoLinkTitle: '',
                 propositionHeader: '',
-                propositionHeaderLink: '/'
+                propositionHeaderLink: '/',
+                logoutRedirectUrl: process.env.LOGOUT_REDIRECT_URL || '/'
             },
             body: {
                 phaseBanner: {

--- a/src/shared/layouts/components/__tests__/__snapshots__/header.spec.jsx.snap
+++ b/src/shared/layouts/components/__tests__/__snapshots__/header.spec.jsx.snap
@@ -1,5 +1,58 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Layout header component should render with custom logout URL 1`] = `
+<header
+  className="govuk-header "
+  data-module="header"
+  role="banner"
+>
+  <div
+    className="govuk-header__container govuk-width-container"
+  >
+    <div
+      className="govuk-header__container govuk-width-container"
+    >
+      <div
+        className="govuk-header__logo"
+      >
+        <span
+          className="govuk-header__logotype"
+        >
+          <Link
+            className="govuk-header__link govuk-header__link--homepage govuk-header__logotype-text"
+            to="/"
+          >
+            Correspondence Service
+          </Link>
+        </span>
+      </div>
+      <div
+        className="govuk-header__content"
+      >
+        <nav>
+          <ul
+            aria-label="Top Level Navigation"
+            className="govuk-header__navigation "
+            id="navigation"
+          >
+            <li
+              className="govuk-header__navigation--end"
+            >
+              <a
+                className="govuk-header__link"
+                href="/oauth/logout?redirect=/foo"
+              >
+                Log out
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+  </div>
+</header>
+`;
+
 exports[`Layout header component should render with default props 1`] = `
 <header
   className="govuk-header "
@@ -42,7 +95,7 @@ exports[`Layout header component should render with default props 1`] = `
                 className="govuk-header__link"
                 href="/oauth/logout?redirect=/"
               >
-                Logout
+                Log out
               </a>
             </li>
           </ul>
@@ -95,7 +148,7 @@ exports[`Layout header component should render without crest when service is not
                 className="govuk-header__link"
                 href="/oauth/logout?redirect=/"
               >
-                Logout
+                Log out
               </a>
             </li>
           </ul>

--- a/src/shared/layouts/components/__tests__/__snapshots__/sessionTimer.spec.tsx.snap
+++ b/src/shared/layouts/components/__tests__/__snapshots__/sessionTimer.spec.tsx.snap
@@ -151,6 +151,7 @@ exports[`Session timer component should render with default props 1`] = `
         },
         "header": Object {
           "isVisible": true,
+          "logoutRedirectUrl": "/",
           "service": "service name",
           "serviceLink": "",
         },

--- a/src/shared/layouts/components/__tests__/header.spec.jsx
+++ b/src/shared/layouts/components/__tests__/header.spec.jsx
@@ -13,4 +13,9 @@ describe('Layout header component', () => {
             shallow(<Header service="Test Service" />)
         ).toMatchSnapshot();
     });
+    it('should render with custom logout URL', () => {
+        expect(
+            shallow(<Header logoutRedirectUrl="/foo" />)
+        ).toMatchSnapshot();
+    });
 });

--- a/src/shared/layouts/components/__tests__/sessionTimer.spec.tsx
+++ b/src/shared/layouts/components/__tests__/sessionTimer.spec.tsx
@@ -18,6 +18,7 @@ describe('Session timer component', () => {
                     isVisible: true,
                     service: 'service name',
                     serviceLink: '',
+                    logoutRedirectUrl: '/'
                 },
             },
             user: {

--- a/src/shared/layouts/components/header.tsx
+++ b/src/shared/layouts/components/header.tsx
@@ -4,7 +4,7 @@ import { HeaderConfig } from 'shared/models/config';
 
 class Header extends Component<HeaderConfig> {
 
-    createLogotype(service: string, serviceLink: string) {
+    createLogotype(service: string, serviceLink: string, logoutRedirectUrl: string) {
         return (
             <div className="govuk-header__container govuk-width-container">
                 <div className="govuk-header__logo">
@@ -16,7 +16,7 @@ class Header extends Component<HeaderConfig> {
                     <nav>
                         <ul id="navigation" className="govuk-header__navigation " aria-label="Top Level Navigation">
                             <li className="govuk-header__navigation--end">
-                                <a href="/oauth/logout?redirect=/" className="govuk-header__link">Logout</a>
+                                <a href={`/oauth/logout?redirect=${logoutRedirectUrl}`} className="govuk-header__link">Log out</a>
                             </li>
                         </ul>
                     </nav>
@@ -26,11 +26,15 @@ class Header extends Component<HeaderConfig> {
     }
 
     render() {
-        const { service = 'Correspondence Service', serviceLink = '/' } = this.props;
+        const {
+            service = 'Correspondence Service',
+            serviceLink = '/',
+            logoutRedirectUrl = '/'
+        } = this.props;
         return (
             <header className="govuk-header " role="banner" data-module="header">
                 <div className="govuk-header__container govuk-width-container">
-                    {this.createLogotype(service, serviceLink)}
+                    {this.createLogotype(service, serviceLink, logoutRedirectUrl)}
                 </div>
             </header>
         );

--- a/src/shared/models/config.ts
+++ b/src/shared/models/config.ts
@@ -2,6 +2,7 @@ export interface HeaderConfig {
     isVisible: boolean;
     service: string;
     serviceLink: string;
+    logoutRedirectUrl: string;
 }
 
 export interface BodyConfig {


### PR DESCRIPTION
Previously the logout URL was hardcoded to /, which actually meant the
root of the Keycloak server and not the URL of the Management UI
homepage.

This commit makes this editable, via an environment variable. I expect
this to be set in the kube config, usually to the $DOMAIN_NAME value,
although another option could be the URL of the non-management DECS.

We also rename "Logout" to "Log out", because it's a verb.