### PR TITLE
HOCS-1983 Remove redirect URL

### DIFF
--- a/src/shared/layouts/components/__tests__/__snapshots__/header.spec.jsx.snap
+++ b/src/shared/layouts/components/__tests__/__snapshots__/header.spec.jsx.snap
@@ -40,7 +40,7 @@ exports[`Layout header component should render with default props 1`] = `
             >
               <a
                 className="govuk-header__link"
-                href="/oauth/logout?redirect=/"
+                href="/oauth/logout"
               >
                 Logout
               </a>
@@ -93,7 +93,7 @@ exports[`Layout header component should render without crest when service is not
             >
               <a
                 className="govuk-header__link"
-                href="/oauth/logout?redirect=/"
+                href="/oauth/logout"
               >
                 Logout
               </a>

--- a/src/shared/layouts/components/__tests__/__snapshots__/header.spec.jsx.snap
+++ b/src/shared/layouts/components/__tests__/__snapshots__/header.spec.jsx.snap
@@ -42,7 +42,7 @@ exports[`Layout header component should render with default props 1`] = `
                 className="govuk-header__link"
                 href="/oauth/logout"
               >
-                Logout
+                Log out
               </a>
             </li>
           </ul>
@@ -95,7 +95,7 @@ exports[`Layout header component should render without crest when service is not
                 className="govuk-header__link"
                 href="/oauth/logout"
               >
-                Logout
+                Log out
               </a>
             </li>
           </ul>

--- a/src/shared/layouts/components/header.tsx
+++ b/src/shared/layouts/components/header.tsx
@@ -16,7 +16,7 @@ class Header extends Component<HeaderConfig> {
                     <nav>
                         <ul id="navigation" className="govuk-header__navigation " aria-label="Top Level Navigation">
                             <li className="govuk-header__navigation--end">
-                                <a href="/oauth/logout" className="govuk-header__link">Logout</a>
+                                <a href="/oauth/logout" className="govuk-header__link">Log out</a>
                             </li>
                         </ul>
                     </nav>

--- a/src/shared/layouts/components/header.tsx
+++ b/src/shared/layouts/components/header.tsx
@@ -16,7 +16,7 @@ class Header extends Component<HeaderConfig> {
                     <nav>
                         <ul id="navigation" className="govuk-header__navigation " aria-label="Top Level Navigation">
                             <li className="govuk-header__navigation--end">
-                                <a href="/oauth/logout?redirect=/" className="govuk-header__link">Logout</a>
+                                <a href="/oauth/logout" className="govuk-header__link">Logout</a>
                             </li>
                         </ul>
                     </nav>


### PR DESCRIPTION
The redirect URL on logout was defined incorrectly, and went to the root
of the Keycloak SSO server instead of the root of the MUI.

This commit removes the hardcoded redirect URL. A redirect URL will
still exist, but we'll pick it up from the values defined within
keycloak-proxy (aka keycloak-gatekeeper).

A downside to this approach is that if the redirect URL isn't defined in
keycloak-proxy it'll default to http://{value from host header} -- which
is mostly fine, but will involve using http:// briefly.

An alternative approach exists in PR #96 to specify explicit redirect
values, but that's adding complexity for minimal benefit. If we decide
to expose the MUI over multiple hostnames, that approach won't work.