### PR TITLE
HOCS-2272 Missing forename/surname of users in MUI shows up as "null"

### DIFF
--- a/server/lists/adapters/__tests__/__snapshots__/users.spec.js.snap
+++ b/server/lists/adapters/__tests__/__snapshots__/users.spec.js.snap
@@ -1,5 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`User Adapter should correctly transform null values 1`] = `
+Array [
+  Object {
+    "label": "A (user.a@example.com)",
+    "value": 1,
+  },
+  Object {
+    "label": "User (user.b@example.com)",
+    "value": 2,
+  },
+  Object {
+    "label": "User C (userC)",
+    "value": 3,
+  },
+  Object {
+    "label": "user.D@example.com",
+    "value": 4,
+  },
+  Object {
+    "label": "userE",
+    "value": 5,
+  },
+]
+`;
+
 exports[`User Adapter should transform and sort user data 1`] = `
 Array [
   Object {

--- a/server/lists/adapters/__tests__/__snapshots__/users.spec.js.snap
+++ b/server/lists/adapters/__tests__/__snapshots__/users.spec.js.snap
@@ -15,12 +15,24 @@ Array [
     "value": 3,
   },
   Object {
-    "label": "user.D@example.com",
+    "label": "D (userD)",
     "value": 4,
   },
   Object {
-    "label": "userE",
+    "label": "User (userE)",
     "value": 5,
+  },
+  Object {
+    "label": "user.F@example.com",
+    "value": 6,
+  },
+  Object {
+    "label": "userG",
+    "value": 7,
+  },
+  Object {
+    "label": "null Null (null.Null@example.com)",
+    "value": 8,
   },
 ]
 `;

--- a/server/lists/adapters/__tests__/users.spec.js
+++ b/server/lists/adapters/__tests__/users.spec.js
@@ -21,4 +21,24 @@ describe('User Adapter', () => {
         expect(results).toBeDefined();
         expect(results).toMatchSnapshot();
     });
+
+    it('should correctly transform null values', async () => {
+        const mockData = [
+            { firstName: null, lastName: 'A', email: 'user.a@example.com', id: 1 },
+            { firstName: 'User', lastName: null, email: 'user.b@example.com', id: 2 },
+            { username: 'userC', firstName: 'User', lastName: 'C', email: null, id: 3 },
+            { username: 'userD', firstName: null, lastName: null, email: 'user.D@example.com', id: 4 },
+            { username: 'userE', firstName: null, lastName: null, email: null, id: 5 }
+        ];
+
+        // Use an id of 0 here to fetch all of the users
+        const results = await usersAdapter(mockData, { user: { id: 0 }, logger: mockLogger });
+        expect(results).toBeDefined();
+        expect(results).toMatchSnapshot();
+        expect(results[0].label).toEqual('A (user.a@example.com)');
+        expect(results[1].label).toEqual('User (user.b@example.com)');
+        expect(results[2].label).toEqual('User C (userC)');
+        expect(results[3].label).toEqual('user.D@example.com');
+        expect(results[4].label).toEqual('userE');
+    });
 });

--- a/server/lists/adapters/__tests__/users.spec.js
+++ b/server/lists/adapters/__tests__/users.spec.js
@@ -24,21 +24,30 @@ describe('User Adapter', () => {
 
     it('should correctly transform null values', async () => {
         const mockData = [
-            { firstName: null, lastName: 'A', email: 'user.a@example.com', id: 1 },
-            { firstName: 'User', lastName: null, email: 'user.b@example.com', id: 2 },
+            { username: 'userA', firstName: null, lastName: 'A', email: 'user.a@example.com', id: 1 },
+            { username: 'userB', firstName: 'User', lastName: null, email: 'user.b@example.com', id: 2 },
             { username: 'userC', firstName: 'User', lastName: 'C', email: null, id: 3 },
-            { username: 'userD', firstName: null, lastName: null, email: 'user.D@example.com', id: 4 },
-            { username: 'userE', firstName: null, lastName: null, email: null, id: 5 }
+            { username: 'userD', firstName: null, lastName: 'D', email: null, id: 4 },
+            { username: 'userE', firstName: 'User', lastName: null, email: null, id: 5 },
+            { username: 'userF', firstName: null, lastName: null, email: 'user.F@example.com', id: 6 },
+            { username: 'userG', firstName: null, lastName: null, email: null, id: 7 },
+            { username: 'userH', firstName: 'null', lastName: 'Null', email: 'null.Null@example.com', id: 8 }
         ];
 
         // Use an id of 0 here to fetch all of the users
         const results = await usersAdapter(mockData, { user: { id: 0 }, logger: mockLogger });
+        results.sort((a, b) => {
+            return a.value - b.value;
+        });
         expect(results).toBeDefined();
         expect(results).toMatchSnapshot();
         expect(results[0].label).toEqual('A (user.a@example.com)');
         expect(results[1].label).toEqual('User (user.b@example.com)');
         expect(results[2].label).toEqual('User C (userC)');
-        expect(results[3].label).toEqual('user.D@example.com');
-        expect(results[4].label).toEqual('userE');
+        expect(results[3].label).toEqual('D (userD)');
+        expect(results[4].label).toEqual('User (userE)');
+        expect(results[5].label).toEqual('user.F@example.com');
+        expect(results[6].label).toEqual('userG');
+        expect(results[7].label).toEqual('null Null (null.Null@example.com)');
     });
 });

--- a/server/lists/adapters/users.js
+++ b/server/lists/adapters/users.js
@@ -4,8 +4,13 @@ module.exports = async (data, { user, logger }) => {
     logger.debug('REQUEST_USERS', { users: data.length });
     return data
         .filter(u => u.id !== user.id)
-        .map(({ id, firstName, lastName, email }) => ({
-            label: `${firstName} ${lastName} (${email})`,
+        // When we do not have a firstName, or lastName we display an empty String, when we do not have an email we display the username,
+        // when we only have an email/username we display it without brackets.
+        .map(({ id, username, firstName, lastName, email }) => ({
+            label: `${((firstName === null) ? '' : firstName + ' ')}` +
+            `${((lastName === null) ? '' : lastName + ' ')}` +
+            `${((email === null) ? (firstName === null && lastName === null) ? username : '(' + username + ')'
+                : (firstName === null && lastName === null) ? email :  '(' + email + ')')}`,
             value: id
         }))
         .sort(byLabel);


### PR DESCRIPTION
On the team management screen and other applicable screens:

    a blank forename in Keycloak should not show up as "null" in the management UI
    a blank surname in Keycloak should not show up as "null" in the management UI
    a blank email in Keycloak should not show up as "null" in the management UI
    a profile with neither forename or surname shouldn't have a bracketed email address

For example,
null null (foo@example.com)
should read

foo@example.com

and

Jane null (foo@example.com)

should read

Jane (foo@example.com) 

But a user actually called "Jane Null" should have their name show up as usual.