### PR TITLE
HOCS-3744: double encode case reference

### DIFF
--- a/server/libs/__tests__/encodingHelpers.spec.js
+++ b/server/libs/__tests__/encodingHelpers.spec.js
@@ -1,0 +1,20 @@
+const encodeCaseReference = require('../encodingHelpers');
+
+describe('Encoding helper', () => {
+    describe('encodeCaseReference', () => {
+        it('should replace all single encoded slashes with double encoded slashes', () => {
+            const singleEncoded = '01/1000002/aaa';
+            const doubleEncoded = encodeCaseReference(singleEncoded);
+
+            expect(doubleEncoded).toBeDefined;
+            expect(doubleEncoded).toEqual('01%252F1000002%252Faaa');
+        });
+
+        it('should return undefined if input is undefined', () => {
+            const singleEncoded = undefined;
+            const doubleEncoded = encodeCaseReference(singleEncoded);
+
+            expect(doubleEncoded).toBeUndefined();
+        });
+    });
+});

--- a/server/libs/encodingHelpers.js
+++ b/server/libs/encodingHelpers.js
@@ -1,0 +1,12 @@
+const doubleEncodeSlashes = (stringToEncode) => {
+    return stringToEncode.split('%2F').join('%252F');
+};
+
+const encodeCaseReference = (referenceToEncode) => {
+    if (referenceToEncode === undefined) {
+        return undefined;
+    }
+    return doubleEncodeSlashes(encodeURIComponent(referenceToEncode));
+};
+
+module.exports = encodeCaseReference;

--- a/server/middleware/case.js
+++ b/server/middleware/case.js
@@ -1,12 +1,13 @@
 const { caseworkService } = require('../clients/index');
 const getLogger = require('../libs/logger');
 const User = require('../models/user');
+const encodeCaseReference = require('../libs/encodingHelpers');
 
 async function withdrawCase(req, res, next) {
     const logger = getLogger(req.request);
 
     try {
-        const encodedReference = encodeURIComponent(req.body.caseReference.toUpperCase());
+        const encodedReference = encodeCaseReference(req.body.caseReference.toUpperCase());
         const requestHeaders = User.createHeaders(req.user);
         const caseData = await caseworkService.get(`/case/data/${encodedReference}`, { headers: requestHeaders });
         if (caseData.data.stages && caseData.data.stages.length > 0) {


### PR DESCRIPTION
Add helper file to assist with double encoding case references. At
present when encoding a case reference of A/0...0/1 this turns to
`A%2F0...0%2F1`. When hocs-casework attempts to resolve the path, this
gets changed back to A/0...0/1 and fails to resolve to the correct path.
Double escaping the slash to %252F allows this to resolve correctly.