### PR TITLE
HOCS-3836: Catch duplicate renames in MUI

### DIFF
--- a/src/shared/pages/list/mpamEnquiryReasons/__tests__/amendEnquiryReason.tsx
+++ b/src/shared/pages/list/mpamEnquiryReasons/__tests__/amendEnquiryReason.tsx
@@ -4,8 +4,10 @@ import { createBrowserHistory, History, Location } from 'history';
 import { act, render, RenderResult, wait, fireEvent, waitForElement } from '@testing-library/react';
 import {
     AMEND_ENQ_REASON_ERROR_DESCRIPTION,
+    DUPLICATE_ENQ_REASON_DESCRIPTION,
     GENERAL_ERROR_TITLE,
-    LOAD_ENQ_SUB_ERROR_DESCRIPTION
+    LOAD_ENQ_SUB_ERROR_DESCRIPTION,
+    VALIDATION_ERROR_TITLE
 } from '../../../../models/constants';
 import * as EntityListService from '../../../../services/entityListService';
 import * as useError from '../../../../hooks/useError';
@@ -170,6 +172,28 @@ describe('when the submit button is clicked', () => {
             it('should call the begin submit action', () => {
                 expect(clearErrorsSpy).toHaveBeenCalled();
             });
+        });
+    });
+
+    describe('and the data already exists', () => {
+        beforeEach(async () => {
+            updateListItemSpy.mockReset();
+            updateListItemSpy.mockImplementationOnce(() => Promise.reject({ response: { status: 409 } }));
+            mockState.title = '__displayName__';
+            mockState.simpleName = '__shortCode__';
+            const submitButton = await waitForElement(async () => {
+                return await wrapper.findByText('Amend');
+            });
+
+            fireEvent.click(submitButton);
+        });
+
+        it('should set the error state', () => {
+            expect(setMessageSpy).toHaveBeenCalledWith({ description: DUPLICATE_ENQ_REASON_DESCRIPTION, title: VALIDATION_ERROR_TITLE });
+        });
+
+        it('should call the begin submit action', () => {
+            expect(clearErrorsSpy).toHaveBeenCalled();
         });
     });
 });

--- a/src/shared/pages/list/mpamEnquiryReasons/amendEnquiryReason.tsx
+++ b/src/shared/pages/list/mpamEnquiryReasons/amendEnquiryReason.tsx
@@ -10,7 +10,10 @@ import ErrorSummary from '../../../common/components/errorSummary';
 import {
     GENERAL_ERROR_TITLE,
     VALIDATION_ERROR_TITLE,
-    LOAD_ENQ_SUB_ERROR_DESCRIPTION, AMEND_ENQ_REASON_SUCCESS, AMEND_ENQ_REASON_ERROR_DESCRIPTION
+    LOAD_ENQ_SUB_ERROR_DESCRIPTION,
+    AMEND_ENQ_REASON_SUCCESS,
+    AMEND_ENQ_REASON_ERROR_DESCRIPTION,
+    DUPLICATE_ENQ_REASON_DESCRIPTION
 } from '../../../models/constants';
 import useError from '../../../hooks/useError';
 import ErrorMessage from '../../../models/errorMessage';
@@ -61,7 +64,11 @@ const AmendEnquiryReason: React.FC<AmendCampaignProps> = ({ csrfToken, history, 
             updateListItem(state, subject).then(() => {
                 history.push('/', { successMessage: AMEND_ENQ_REASON_SUCCESS });
             }).catch((error) => {
-                setErrorMessage(new ErrorMessage(AMEND_ENQ_REASON_ERROR_DESCRIPTION, GENERAL_ERROR_TITLE));
+                if (error && error.response && error.response.status === 409) {
+                    setErrorMessage(new ErrorMessage(DUPLICATE_ENQ_REASON_DESCRIPTION, VALIDATION_ERROR_TITLE));
+                } else {
+                    setErrorMessage(new ErrorMessage(AMEND_ENQ_REASON_ERROR_DESCRIPTION, GENERAL_ERROR_TITLE));
+                }
             });
         }
     };


### PR DESCRIPTION
Currently, the MUI does not catch 409 errors when amending enquiry
reasons. This change adds a check for 409 errors and a test to make sure
that they display correctly.