### PR TITLE
HOCS-3639: Set simpleName in addEnquiryReasons

### DIFF
--- a/src/shared/pages/list/mpamEnquiryReasons/addEnquiryReasonReducer.ts
+++ b/src/shared/pages/list/mpamEnquiryReasons/addEnquiryReasonReducer.ts
@@ -2,6 +2,6 @@ import EntityListItem from '../../../models/entityListItem';
 import InputEventData from '../../../models/inputEventData';
 
 export const reducer = (state: EntityListItem, inputEventData: InputEventData) => {
-    const newState = { ...state, [inputEventData.name]: inputEventData.value, simpleName: inputEventData.value };
+    const newState = { ...state, [inputEventData.name]: inputEventData.value, simpleName: inputEventData.value.toString() };
     return newState;
 };

--- a/src/shared/pages/list/mpamEnquiryReasons/addEnquiryReasonReducer.ts
+++ b/src/shared/pages/list/mpamEnquiryReasons/addEnquiryReasonReducer.ts
@@ -2,7 +2,6 @@ import EntityListItem from '../../../models/entityListItem';
 import InputEventData from '../../../models/inputEventData';
 
 export const reducer = (state: EntityListItem, inputEventData: InputEventData) => {
-    state.simpleName = inputEventData.value.toString();
-    const newState = { ...state, [inputEventData.name]: inputEventData.value };
+    const newState = { ...state, [inputEventData.name]: inputEventData.value, simpleName: inputEventData.value };
     return newState;
 };

--- a/src/shared/pages/list/mpamEnquiryReasons/addEnquiryReasonReducer.ts
+++ b/src/shared/pages/list/mpamEnquiryReasons/addEnquiryReasonReducer.ts
@@ -2,6 +2,7 @@ import EntityListItem from '../../../models/entityListItem';
 import InputEventData from '../../../models/inputEventData';
 
 export const reducer = (state: EntityListItem, inputEventData: InputEventData) => {
+    state.simpleName = inputEventData.value.toString();
     const newState = { ...state, [inputEventData.name]: inputEventData.value };
     return newState;
 };


### PR DESCRIPTION
Currently, the simpleName is not being set when requests are sent to
add enquiry reasons via the MUI. This makes the new reasons all detect
as duplicate and makes them unselectable in the frontend. This change
adds this value to requests sent this way.