### PR TITLE
Add Dependabot Config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "⬆️ "
+    pull-request-branch-name:
+      separator: "-"
+    reviewers:
+      - "UKHomeOffice/hocs-core"


### PR DESCRIPTION
Add dependabot configuration to enable dependency updating with security
issues. This config specifies that the repository uses NPM, too assign
the hocs-core team to the PR and also changes the separator to '-' to
work with drone.