### PR TITLE
Fix yearly snapshot issue

### DIFF
--- a/src/shared/pages/standardLineAdd/__tests__/addStandardLine.spec.tsx
+++ b/src/shared/pages/standardLineAdd/__tests__/addStandardLine.spec.tsx
@@ -9,6 +9,7 @@ import StandardLine from '../../../models/standardLine';
 import * as useError from '../../../hooks/useError';
 import * as TopicsService from '../../../services/topicsService';
 import { createMockFile } from '../../../../../test/createMockFile';
+import { advanceTo } from 'jest-date-mock';
 
 jest.mock('../../../services/topicsService', () => ({
     __esModule: true,
@@ -72,6 +73,7 @@ beforeEach(() => {
     addFormErrorSpy.mockReset();
     clearErrorsSpy.mockReset();
     setMessageSpy.mockReset();
+    advanceTo(new Date(1640995200000)); // reset to date time.
     act(() => {
         wrapper = renderComponent();
     });


### PR DESCRIPTION
Every year the addStandardLine.spec.tsx snapshot fails due to the date
not being mocked. This change uses the jest-date-mock library to change
the dates timestamp to 00:00:00 on the 2022-01-01. This leads to this
change not being needed to be made every year.