### PR TITLE
Hocs-4696: Remove Sonar scan - should be done as another ticket

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -167,13 +167,6 @@ steps:
     depends_on:
       - install dependencies
 
-  - name: sonar scanner
-    image: quay.io/ukhomeofficedigital/sonar-scanner
-    commands:
-      - sonar-scanner -Dsonar.projectVersion="$(git rev-parse --abbrev-ref HEAD)"
-    depends_on:
-      - test project
-
   - name: build & push
     image: plugins/docker
     settings:


### PR DESCRIPTION
Hocs-4696: Sonar was added to the pipeline but is not configured for management-UI yet, it should be removed and done as a new ticket.