### PR TITLE
HOCS-5375 Fix max header error

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-exec node index.js
+exec node --max-http-header-size 80000 index.js


### PR DESCRIPTION
This commit re-inserts the --max-header-size command-line parameter
which was in package.json but not correctly transferred to run.sh.

This is required as newer versions of NodeJS have a smaller header size
than we use (due to the large group headers inserted by
keycloak-gatekeeper).

We picked 80,000 bytes as it is the default in NodeJS 8 (HOCS-2361).