### PR TITLE
Update default S3 Region in config

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -51,7 +51,7 @@ const config = {
                 SECRET_ACCESS_KEY: process.env.S3_SECRET_ACCESS_KEY || 'UNSET',
                 ENDPOINT: isProduction ? null : process.env.S3_ENDPOINT || 'http://localhost:4566',
                 PROXY: isProduction ? process.env.OUTBOUND_PROXY : null,
-                REGION: isProduction ? process.env.S3_REGION : null,
+                REGION: isProduction ? process.env.S3_REGION : 'eu-west-2',
                 SSL_ENABLED: isProduction,
                 FORCE_PATH_STYLE: !isProduction,
                 SSE_KEY: isProduction ? process.env.S3_SSE_KEY : null


### PR DESCRIPTION
Changes the default S3 Region from null to eu-west-2.
Alternative region can still be passed through environment variable if required.