### PR TITLE
Ignore AWS-SDK dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,3 +52,6 @@ updates:
     labels:
       - "patch"
       - "dependencies"
+    ignore:
+      - dependency-name: "aws-sdk"
+        update-types: [ "version-update:semver-minor" ] # aws-sdk automatically pushes new minor version daily


### PR DESCRIPTION
The dependency is automatically bumped by a minor version daily for the entire aws-sdk. This causes unnecessary dependabot updates. This change stops this update type, although security fixes will override this.